### PR TITLE
Using more general type (IEnumerable) as input parameter

### DIFF
--- a/src/Application/Common/Exceptions/ValidationException.cs
+++ b/src/Application/Common/Exceptions/ValidationException.cs
@@ -13,7 +13,7 @@ namespace CleanArchitecture.Application.Common.Exceptions
             Failures = new Dictionary<string, string[]>();
         }
 
-        public ValidationException(List<ValidationFailure> failures)
+        public ValidationException(IEnumerable<ValidationFailure> failures)
             : this()
         {
             var failureGroups = failures


### PR DESCRIPTION
I've changed List to IEnumerable according to ["**Parameter Design**"](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/parameter-design) section of "**Microsoft Design Guidelines**":

> ✔ **DO** use the least derived parameter type that provides the functionality required by the member.
> 
> For example, suppose you want to design a method that enumerates a collection and prints each item to the console. Such a method should take IEnumerable as the parameter, not ArrayList or IList, for example.