### PR TITLE
add database migrations to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To use `dotnet-ef` for your migrations please add the following flags to your co
 
 - `--project src/Infrastructure` (optional if in this folder)
 - `--startup-project src/WebUI`
-- `--output-dir Persistance/Migrations`
+- `--output-dir Persistence/Migrations`
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ This layer contains classes for accessing external resources such as file system
 
 This layer is a single page application based on Angular 8 and ASP.NET Core 3. This layer depends on both the Application and Infrastructure layers, however, the dependency on Infrastructure is only to support dependency injection. Therefore only *Startup.cs* should reference Infrastructure.
 
+## Notes
+
+### Database Migrations
+
+To use `dotnet-ef` for your migrations please add the following flags to your command (values assume you are executing from repository root)
+
+- `--project src/Infrastructure` (optional if in this folder)
+- `--startup-project src/WebUI`
+- `--output-dir Persistance/Migrations`
+
 ## Support
 
 If you are having problems, please let us know by [raising a new issue](https://github.com/JasonGT/CleanArchitecture/issues/new/choose).


### PR DESCRIPTION
Add details on flags needed to run database migrations as it can be fairly confusing for people coming from a traditional single project world. (or perhaps one in which your migrations are within your web project.)

In relation to issue #33

This readme change is likely out of scope. If you feel this way please reject this PR outright. Thank you!