### PR TITLE
Added password config to remove digit requirement. Fixes #68.

### DIFF
--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -29,8 +29,16 @@ namespace CleanArchitecture.Infrastructure
 
             services.AddScoped<IApplicationDbContext>(provider => provider.GetService<ApplicationDbContext>());
 
-            services.AddDefaultIdentity<ApplicationUser>()
-                .AddEntityFrameworkStores<ApplicationDbContext>();
+            services.AddDefaultIdentity<ApplicationUser>(options =>
+            {
+                // Basic built in validations
+                options.Password.RequireDigit = false;
+                options.Password.RequireLowercase = true;
+                options.Password.RequireNonAlphanumeric = true;
+                options.Password.RequireUppercase = true;
+                options.Password.RequiredLength = 6;
+            })
+            .AddEntityFrameworkStores<ApplicationDbContext>();
 
             if (environment.IsEnvironment("Test"))
             {

--- a/src/Infrastructure/Persistence/ApplicationDbContextSeed.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContextSeed.cs
@@ -11,7 +11,8 @@ namespace CleanArchitecture.Infrastructure.Persistence
         {
             var defaultUser = new ApplicationUser { UserName = "jason@clean-architecture", Email = "jason@clean-architecture" };
 
-            if (userManager.Users.All(u => u.Id != defaultUser.Id))
+            // Add default user if not already present
+            if (userManager.Users.All(u => u.UserName != defaultUser.UserName))
             {
                 await userManager.CreateAsync(defaultUser, "CleanArchitecture!");
             }


### PR DESCRIPTION
Fixes a bug in `ApplicationDbContextSeed` where adding a user with a password that violates the password requirements silently fails and does not add the user to the Db.