### PR TITLE
Updated read me to correct the sample migration code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ To use `dotnet-ef` for your migrations please add the following flags to your co
 
 - `--project src/Infrastructure` (optional if in this folder)
 - `--startup-project src/WebUI`
-- `--output-dir Persistence/Migrations`
+- `--output-dir Migrations`
 
 For example, to add a new migration from the root folder:
 
- `dotnet ef migrations add "SampleMigration" --project src\Infrastructure --startup-project src\WebUI --output-dir Persistence\Migrations`
+ `dotnet ef migrations add "SampleMigration" --project src\Infrastructure --startup-project src\WebUI --output-dir Migrations`
 
 ## Overview
 


### PR DESCRIPTION
The folder sturcture was altered and the migration folder was moved from Infrastructure\Persistence\Migrations to Infrastructure\Migrations. 

Trying to use the migration code sample on currently on the ReadMe file lead to erros due to the creation of a new Migration folder inside Persistance with another ApplicationDbContextModelSnapshot file.

ReadMe file was updated to reflect this change, and update the sample code