### PR TITLE
Add frontend interceptors

### DIFF
--- a/src/WebUI/ClientApp/src/app/app.module.ts
+++ b/src/WebUI/ClientApp/src/app/app.module.ts
@@ -14,6 +14,8 @@ import { TodoComponent } from './todo/todo.component';
 import { ApiAuthorizationModule } from 'src/api-authorization/api-authorization.module';
 import { AuthorizeGuard } from 'src/api-authorization/authorize.guard';
 import { AuthorizeInterceptor } from 'src/api-authorization/authorize.interceptor';
+import { GlobalErrorHandler } from 'src/error-handling/global-error.handler';
+import { ServerErrorInterceptor } from 'src/error-handling/server-error.interceptor';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ModalModule } from 'ngx-bootstrap/modal';
 
@@ -43,6 +45,8 @@ import { ModalModule } from 'ngx-bootstrap/modal';
   ],
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: AuthorizeInterceptor, multi: true },
+    { provide: GlobalErrorHandler, useClass: GlobalErrorHandler },
+    { provide: HTTP_INTERCEPTORS, useClass: ServerErrorInterceptor, multi: true }
   ],
   bootstrap: [AppComponent]
 })

--- a/src/WebUI/ClientApp/src/error-handling/global-error.handler.spec.ts
+++ b/src/WebUI/ClientApp/src/error-handling/global-error.handler.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { GlobalErrorHandler } from './global-error.handler';
+
+describe('AuthorizeInterceptor', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [GlobalErrorHandler]
+    });
+  });
+
+  it('should be created', inject([GlobalErrorHandler], (service: GlobalErrorHandler) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/WebUI/ClientApp/src/error-handling/global-error.handler.ts
+++ b/src/WebUI/ClientApp/src/error-handling/global-error.handler.ts
@@ -1,0 +1,9 @@
+import { ErrorHandler, Injectable } from '@angular/core';
+
+@Injectable()
+export class GlobalErrorHandler implements ErrorHandler {
+
+  handleError(error) {
+    // your custom error handling logic    
+  }
+}

--- a/src/WebUI/ClientApp/src/error-handling/server-error-interceptor.spec.ts
+++ b/src/WebUI/ClientApp/src/error-handling/server-error-interceptor.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { ServerErrorInterceptor } from './server-error.interceptor';
+
+describe('AuthorizeInterceptor', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ServerErrorInterceptor]
+    });
+  });
+
+  it('should be created', inject([ServerErrorInterceptor], (service: ServerErrorInterceptor) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/WebUI/ClientApp/src/error-handling/server-error.interceptor.ts
+++ b/src/WebUI/ClientApp/src/error-handling/server-error.interceptor.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent, HttpRequest, HttpHandler,
+  HttpInterceptor, HttpErrorResponse
+} from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { retry, catchError } from 'rxjs/operators';
+
+@Injectable()
+export class ServerErrorInterceptor implements HttpInterceptor {
+
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+
+    return next.handle(request).pipe(
+      retry(1),
+      catchError((error: HttpErrorResponse) => {
+        if (error.status === 401) {
+          // refresh token
+        } else {
+          return throwError(error);
+        }
+      })
+    );
+  }
+}

--- a/src/WebUI/ClientApp/src/error-handling/server-error.interceptor.ts
+++ b/src/WebUI/ClientApp/src/error-handling/server-error.interceptor.ts
@@ -17,6 +17,7 @@ export class ServerErrorInterceptor implements HttpInterceptor {
         if (error.status === 401) {
           // refresh token
         } else {
+          //Add custom error handling here. Logging or snack bar display
           return throwError(error);
         }
       })


### PR DESCRIPTION
#106  adds functial mentioned in issue.

Interceptors are added for both frontend code in general and httpresponses.
Two handlers in ClientApp\src\error-handling and registered in main module.
They should be self explanitory.

Cheers!
