### PR TITLE
Remove constructor and use collection initializer

### DIFF
--- a/src/Domain/Entities/TodoList.cs
+++ b/src/Domain/Entities/TodoList.cs
@@ -5,17 +5,12 @@ namespace CleanArchitecture.Domain.Entities
 {
     public class TodoList : AuditableEntity
     {
-        public TodoList()
-        {
-            Items = new List<TodoItem>();
-        }
-
         public int Id { get; set; }
 
         public string Title { get; set; }
 
         public string Colour { get; set; }
 
-        public IList<TodoItem> Items { get; set; }
+        public IList<TodoItem> Items { get; set; } = new List<TodoItem>();
     }
 }

--- a/src/Domain/Entities/TodoList.cs
+++ b/src/Domain/Entities/TodoList.cs
@@ -11,6 +11,6 @@ namespace CleanArchitecture.Domain.Entities
 
         public string Colour { get; set; }
 
-        public IList<TodoItem> Items { get; set; } = new List<TodoItem>();
+        public IList<TodoItem> Items { get; private set; } = new List<TodoItem>();
     }
 }


### PR DESCRIPTION
It's better to initialize the collection in the declaration so that if more constructors were added, there would be no need to initialize the collection in every constructor.