### PR TITLE
Changed HttpContextAccessor to retrieve context when getter is called

### DIFF
--- a/src/WebUI/Services/CurrentUserService.cs
+++ b/src/WebUI/Services/CurrentUserService.cs
@@ -6,11 +6,13 @@ namespace CleanArchitecture.WebUI.Services
 {
     public class CurrentUserService : ICurrentUserService
     {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
         public CurrentUserService(IHttpContextAccessor httpContextAccessor)
         {
-            UserId = httpContextAccessor.HttpContext?.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+            _httpContextAccessor = httpContextAccessor;
         }
 
-        public string UserId { get; }
+        public string UserId => _httpContextAccessor.HttpContext?.User?.FindFirstValue(ClaimTypes.NameIdentifier);
     }
 }

--- a/src/WebUI/Startup.cs
+++ b/src/WebUI/Startup.cs
@@ -32,7 +32,7 @@ namespace CleanArchitecture.WebUI
             services.AddApplication();
             services.AddInfrastructure(Configuration);
 
-            services.AddScoped<ICurrentUserService, CurrentUserService>();
+            services.AddSingleton<ICurrentUserService, CurrentUserService>();
 
             services.AddHttpContextAccessor();
 


### PR DESCRIPTION
Since `HttpContext` is using `AsyncLocal` internal while the `CurrentUserService` is using DI (scope), there might be cases where there is a synchronisation issue that causes the wrong or `null` UserId to be returned.  Is it safe to have a Singleton service which retrieves the current context from the accessor as suggested by David Fowler - https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AspNetCoreGuidance.md#do-not-store-ihttpcontextaccessorhttpcontext-in-a-field