### PR TITLE
Made NSwag output filename lowercase

### DIFF
--- a/src/WebUI/nswag.json
+++ b/src/WebUI/nswag.json
@@ -110,7 +110,7 @@
       "enumNameGeneratorType": null,
       "serviceHost": null,
       "serviceSchemes": null,
-      "output": "ClientApp/src/app/CleanArchitecture-api.ts"
+      "output": "ClientApp/src/app/cleanarchitecture-api.ts"
     }
   }
 }


### PR DESCRIPTION
This fixes an issue (#176) with resolving the Angular client after initializing the template on a Linux machine (which has case-sensitivity for filepaths).