### PR TITLE
Private setter on collections in domain entity

### DIFF
--- a/src/Domain/Entities/TodoList.cs
+++ b/src/Domain/Entities/TodoList.cs
@@ -16,6 +16,6 @@ namespace CleanArchitecture.Domain.Entities
 
         public string Colour { get; set; }
 
-        public IList<TodoItem> Items { get; set; }
+        public IList<TodoItem> Items { get; private set; }
     }
 }


### PR DESCRIPTION
Implement the change made during the GOTO 2019 talk here:
https://youtu.be/dK4Yb6-LxAk?t=800

Private setters on collections prevent collection overriding.