### PR TITLE
[Feature] Domain Events

### DIFF
--- a/src/Application/Common/Interfaces/IDomainEventService.cs
+++ b/src/Application/Common/Interfaces/IDomainEventService.cs
@@ -1,0 +1,10 @@
+﻿using CleanArchitecture.Domain.Common;
+using System.Threading.Tasks;
+
+namespace CleanArchitecture.Application.Common.Interfaces
+{
+    public interface IDomainEventService
+    {
+        Task Publish(DomainEvent domainEvent);
+    }
+}

--- a/src/Application/Common/Models/DomainEventNotification.cs
+++ b/src/Application/Common/Models/DomainEventNotification.cs
@@ -1,0 +1,15 @@
+﻿using CleanArchitecture.Domain.Common;
+using MediatR;
+
+namespace CleanArchitecture.Application.Common.Models
+{
+    public class DomainEventNotification<TDomainEvent> : INotification where TDomainEvent : DomainEvent
+    {
+        public DomainEventNotification(TDomainEvent domainEvent)
+        {
+            DomainEvent = domainEvent;
+        }
+
+        public TDomainEvent DomainEvent { get; }
+    }
+}

--- a/src/Application/TodoItems/Commands/CreateTodoItem/CreateTodoItemCommand.cs
+++ b/src/Application/TodoItems/Commands/CreateTodoItem/CreateTodoItemCommand.cs
@@ -1,5 +1,6 @@
 ﻿using CleanArchitecture.Application.Common.Interfaces;
 using CleanArchitecture.Domain.Entities;
+using CleanArchitecture.Domain.Events;
 using MediatR;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,6 +31,8 @@ namespace CleanArchitecture.Application.TodoItems.Commands.CreateTodoItem
                 Title = request.Title,
                 Done = false
             };
+
+            entity.DomainEvents.Add(new TodoItemCreatedEvent(entity));
 
             _context.TodoItems.Add(entity);
 

--- a/src/Application/TodoItems/EventHandlers/TodoItemCompletedEventHandler.cs
+++ b/src/Application/TodoItems/EventHandlers/TodoItemCompletedEventHandler.cs
@@ -1,0 +1,27 @@
+﻿using CleanArchitecture.Application.Common.Models;
+using CleanArchitecture.Domain.Events;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CleanArchitecture.Application.TodoItems.EventHandlers
+{
+    public class TodoItemCompletedEventHandler : INotificationHandler<DomainEventNotification<TodoItemCompletedEvent>>
+    {
+        private readonly ILogger<TodoItemCompletedEventHandler> _logger;
+
+        public TodoItemCompletedEventHandler(ILogger<TodoItemCompletedEventHandler> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task Handle(DomainEventNotification<TodoItemCompletedEvent> notification, CancellationToken cancellationToken)
+        {
+            var domainEvent = notification.DomainEvent;
+            _logger.LogInformation("Domain event - {domainEvent} handler called", domainEvent.GetType().Name);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Application/TodoItems/EventHandlers/TodoItemCreatedEventHandler.cs
+++ b/src/Application/TodoItems/EventHandlers/TodoItemCreatedEventHandler.cs
@@ -1,0 +1,27 @@
+﻿using CleanArchitecture.Application.Common.Models;
+using CleanArchitecture.Domain.Events;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CleanArchitecture.Application.TodoItems.EventHandlers
+{
+    public class TodoItemCreatedEventHandler : INotificationHandler<DomainEventNotification<TodoItemCreatedEvent>>
+    {
+        private readonly ILogger<TodoItemCompletedEventHandler> _logger;
+
+        public TodoItemCreatedEventHandler(ILogger<TodoItemCompletedEventHandler> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task Handle(DomainEventNotification<TodoItemCreatedEvent> notification, CancellationToken cancellationToken)
+        {
+            var domainEvent = notification.DomainEvent;
+            _logger.LogInformation("Domain event - {domainEvent} handled", domainEvent.GetType().Name);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Domain/Common/AuditableEntity.cs
+++ b/src/Domain/Common/AuditableEntity.cs
@@ -1,15 +1,18 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace CleanArchitecture.Domain.Common
 {
     public abstract class AuditableEntity
     {
-        public string CreatedBy { get; set; }
-
         public DateTime Created { get; set; }
 
-        public string LastModifiedBy { get; set; }
+        public string CreatedBy { get; set; }
+
+        public List<DomainEvent> Events { get; } = new List<DomainEvent>();
 
         public DateTime? LastModified { get; set; }
+
+        public string LastModifiedBy { get; set; }
     }
 }

--- a/src/Domain/Common/AuditableEntity.cs
+++ b/src/Domain/Common/AuditableEntity.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace CleanArchitecture.Domain.Common
 {
@@ -8,8 +7,6 @@ namespace CleanArchitecture.Domain.Common
         public DateTime Created { get; set; }
 
         public string CreatedBy { get; set; }
-
-        public List<DomainEvent> Events { get; } = new List<DomainEvent>();
 
         public DateTime? LastModified { get; set; }
 

--- a/src/Domain/Common/DomainEvent.cs
+++ b/src/Domain/Common/DomainEvent.cs
@@ -1,19 +1,20 @@
-﻿using MediatR;
-using System;
-using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
 
 namespace CleanArchitecture.Domain.Common
 {
-    public abstract class DomainEvent : INotification
+    public interface IHasDomainEvent
     {
-        public static Func<IMediator> Mediator { get; set; }
+        public List<DomainEvent> DomainEvents { get; set; }
+    }
 
-        public DateTime DateOccurred { get; protected set; } = DateTime.UtcNow;
-
-        public static async Task Raise<T>(T args) where T : INotification
+    public abstract class DomainEvent
+    {
+        protected DomainEvent()
         {
-            IMediator mediator = Mediator.Invoke();
-            await mediator.Publish<T>(args);
+            DateOccurred = DateTimeOffset.UtcNow;
         }
+
+        public DateTimeOffset DateOccurred { get; protected set; } = DateTime.UtcNow;
     }
 }

--- a/src/Domain/Common/DomainEvent.cs
+++ b/src/Domain/Common/DomainEvent.cs
@@ -1,0 +1,19 @@
+﻿using MediatR;
+using System;
+using System.Threading.Tasks;
+
+namespace CleanArchitecture.Domain.Common
+{
+    public abstract class DomainEvent : INotification
+    {
+        public static Func<IMediator> Mediator { get; set; }
+
+        public DateTime DateOccurred { get; protected set; } = DateTime.UtcNow;
+
+        public static async Task Raise<T>(T args) where T : INotification
+        {
+            IMediator mediator = Mediator.Invoke();
+            await mediator.Publish<T>(args);
+        }
+    }
+}

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -6,8 +6,4 @@
     <AssemblyName>CleanArchitecture.Domain</AssemblyName>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MediatR" Version="8.1.0" />
-  </ItemGroup>
-
 </Project>

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -6,4 +6,8 @@
     <AssemblyName>CleanArchitecture.Domain</AssemblyName>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="MediatR" Version="8.1.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/Domain/Entities/TodoItem.cs
+++ b/src/Domain/Entities/TodoItem.cs
@@ -1,26 +1,47 @@
 ﻿using CleanArchitecture.Domain.Common;
 using CleanArchitecture.Domain.Enums;
+using CleanArchitecture.Domain.Events;
 using System;
+using System.Collections.Generic;
 
 namespace CleanArchitecture.Domain.Entities
 {
-    public class TodoItem : AuditableEntity
+    public class TodoItem : AuditableEntity, IHasDomainEvent
     {
+        private bool _done;
+
+        public TodoItem()
+        {
+            DomainEvents = new List<DomainEvent>();
+        }
+
+        public List<DomainEvent> DomainEvents { get; set; }
+
+        public bool Done
+        {
+            get => _done;
+            set
+            {
+                if (value == true && _done == false)
+                {
+                    DomainEvents.Add(new TodoItemCompletedEvent(this));
+                }
+                _done = value;
+            }
+        }
+
         public int Id { get; set; }
+
+        public TodoList List { get; set; }
 
         public int ListId { get; set; }
 
-        public string Title { get; set; }
-
         public string Note { get; set; }
-
-        public bool Done { get; set; }
-
-        public DateTime? Reminder { get; set; }
 
         public PriorityLevel Priority { get; set; }
 
+        public DateTime? Reminder { get; set; }
 
-        public TodoList List { get; set; }
+        public string Title { get; set; }
     }
 }

--- a/src/Domain/Events/TodoItemCompletedEvent.cs
+++ b/src/Domain/Events/TodoItemCompletedEvent.cs
@@ -1,0 +1,15 @@
+﻿using CleanArchitecture.Domain.Common;
+using CleanArchitecture.Domain.Entities;
+
+namespace CleanArchitecture.Domain.Events
+{
+    public class TodoItemCompletedEvent : DomainEvent
+    {
+        public TodoItemCompletedEvent(TodoItem item)
+        {
+            Item = item;
+        }
+
+        public TodoItem Item { get; }
+    }
+}

--- a/src/Domain/Events/TodoItemCreatedEvent.cs
+++ b/src/Domain/Events/TodoItemCreatedEvent.cs
@@ -1,0 +1,15 @@
+﻿using CleanArchitecture.Domain.Common;
+using CleanArchitecture.Domain.Entities;
+
+namespace CleanArchitecture.Domain.Events
+{
+    public class TodoItemCreatedEvent : DomainEvent
+    {
+        public TodoItemCreatedEvent(TodoItem item)
+        {
+            Item = item;
+        }
+
+        public TodoItem Item { get; }
+    }
+}

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -29,9 +29,11 @@ namespace CleanArchitecture.Infrastructure
 
             services.AddScoped<IApplicationDbContext>(provider => provider.GetService<ApplicationDbContext>());
 
-                services.AddDefaultIdentity<ApplicationUser>()
-                    .AddEntityFrameworkStores<ApplicationDbContext>();
-            
+            services.AddScoped<IDomainEventService, DomainEventService>();
+
+            services.AddDefaultIdentity<ApplicationUser>()
+                .AddEntityFrameworkStores<ApplicationDbContext>();
+
             services.AddIdentityServer()
                 .AddApiAuthorization<ApplicationUser, ApplicationDbContext>();
 

--- a/src/Infrastructure/Persistence/Configurations/TodoItemConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/TodoItemConfiguration.cs
@@ -8,7 +8,7 @@ namespace CleanArchitecture.Infrastructure.Persistence.Configurations
     {
         public void Configure(EntityTypeBuilder<TodoItem> builder)
         {
-            builder.Ignore(e => e.Events);
+            builder.Ignore(e => e.DomainEvents);
 
             builder.Property(t => t.Title)
                 .HasMaxLength(200)

--- a/src/Infrastructure/Persistence/Configurations/TodoItemConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/TodoItemConfiguration.cs
@@ -8,6 +8,8 @@ namespace CleanArchitecture.Infrastructure.Persistence.Configurations
     {
         public void Configure(EntityTypeBuilder<TodoItem> builder)
         {
+            builder.Ignore(e => e.Events);
+
             builder.Property(t => t.Title)
                 .HasMaxLength(200)
                 .IsRequired();

--- a/src/Infrastructure/Persistence/Configurations/TodoListConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/TodoListConfiguration.cs
@@ -1,5 +1,4 @@
-﻿
-using CleanArchitecture.Domain.Entities;
+﻿using CleanArchitecture.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -9,6 +8,8 @@ namespace CleanArchitecture.Infrastructure.Persistence.Configurations
     {
         public void Configure(EntityTypeBuilder<TodoList> builder)
         {
+            builder.Ignore(e => e.Events);
+
             builder.Property(t => t.Title)
                 .HasMaxLength(200)
                 .IsRequired();

--- a/src/Infrastructure/Persistence/Configurations/TodoListConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/TodoListConfiguration.cs
@@ -8,8 +8,6 @@ namespace CleanArchitecture.Infrastructure.Persistence.Configurations
     {
         public void Configure(EntityTypeBuilder<TodoList> builder)
         {
-            builder.Ignore(e => e.Events);
-
             builder.Property(t => t.Title)
                 .HasMaxLength(200)
                 .IsRequired();

--- a/src/Infrastructure/Services/DomainEventService.cs
+++ b/src/Infrastructure/Services/DomainEventService.cs
@@ -1,0 +1,34 @@
+﻿using CleanArchitecture.Application.Common.Interfaces;
+using CleanArchitecture.Application.Common.Models;
+using CleanArchitecture.Domain.Common;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace CleanArchitecture.Infrastructure.Services
+{
+    public class DomainEventService : IDomainEventService
+    {
+        private readonly ILogger<DomainEventService> _logger;
+        private readonly IMediator _mediator;
+
+        public DomainEventService(ILogger<DomainEventService> logger, IMediator mediator)
+        {
+            _logger = logger;
+            _mediator = mediator;
+        }
+
+        public async Task Publish(DomainEvent domainEvent)
+        {
+            _logger.LogInformation("Publishing domain event. Event - {event}", domainEvent.GetType().Name);
+            await _mediator.Publish(GetNotificationCorrespondingToDomainEvent(domainEvent));
+        }
+
+        private INotification GetNotificationCorrespondingToDomainEvent(DomainEvent domainEvent)
+        {
+            return (INotification)Activator.CreateInstance(
+                typeof(DomainEventNotification<>).MakeGenericType(domainEvent.GetType()), domainEvent);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds Domain Events to the solution template.  Domain events implement side effects of changes across multiple aggregates, entities or services and provide very loose coupling.  Let's look at an example:

When a user places an order with an online store an email is sent back to the user confirming the purchase.  This could be done in a workflow in a single command where the data is saved to the database and then an email is sent.  Or you can handle the order placed as a command that throws an order placed event.  Then a separate event handler can send the email.  If in the future a new action is identified such as also sending an email to the fulfillment center, it can be added without changing the previous command.

There are two separate ways to fire domain events.

1. **During Save Changes.** This is based off Jimmy Bogart's [A Better Domain Events Pattern](https://lostechies.com/jimmybogard/2014/05/13/a-better-domain-events-pattern/). This is a simple and straightforward way to attach events to the domain model that are fired when the object is persisted to the database. Microsoft also has documentation on domain events with a similar implementation in the microservices architecture book in the section [Domain events: design and implementation](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/microservice-ddd-cqrs-patterns/domain-events-design-implementation). An implementation and example of this pattern is included in the PR.

2. **Independent of Persistence.** This one is based on Steve Smith's [Immediate Domain Event Salvation with MediatR](https://ardalis.com/immediate-domain-event-salvation-with-mediatr/). It takes a different approach using a static method that lets you fire events at any time.  This option is **not** included in this PR.  If we want to add this it can be done with a static domain event class that has a Raise method on it.  I'm not sure if two different domain event handlers should be included in the template.

**Example Included**

The To Do Item Created Event is will be thrown by the create command.

```c#
    public class TodoItemCreatedEvent : DomainEvent
    {
        public TodoItemCreatedEvent(TodoItem item)
        {
            Item = item;
        }

        public TodoItem Item { get; }
    }
```

The To Do Item Completed Event Handle will catch the event.

```c#
    public class TodoItemCompletedEventHandler : INotificationHandler<DomainEventNotification<TodoItemCompletedEvent>>
    {
        private readonly ILogger<TodoItemCompletedEventHandler> _logger;

        public TodoItemCompletedEventHandler(ILogger<TodoItemCompletedEventHandler> logger)
        {
            _logger = logger;
        }

        public Task Handle(DomainEventNotification<TodoItemCompletedEvent> notification, CancellationToken cancellationToken)
        {
            var domainEvent = notification.DomainEvent;
            _logger.LogInformation("Domain event - {domainEvent} handler called", domainEvent.GetType().Name);

            return Task.CompletedTask;
        }
    }
````

The flow will work like this:

1. The Create To Do Command adds the event:

```c#
    ...
     entity.DomainEvents.Add(new TodoItemCreatedEvent(entity));
    ...
```

2. The event is fired during the Save Changes:

```c#
await DispatchEvents(cancellationToken);
```

3. The To Do Item Completed Handler is executed because it is specifically design to listen to that event:

```c#
INotificationHandler<DomainEventNotification<TodoItemCompletedEvent>>
```

