### PR TITLE
refactor(value object)

### DIFF
--- a/src/Domain/Common/ValueObject.cs
+++ b/src/Domain/Common/ValueObject.cs
@@ -21,7 +21,7 @@ namespace CleanArchitecture.Domain.Common
             return !(EqualOperator(left, right));
         }
 
-        protected abstract IEnumerable<object> GetAtomicValues();
+        protected abstract IEnumerable<object> GetEqualityComponents();
 
         public override bool Equals(object obj)
         {
@@ -31,29 +31,12 @@ namespace CleanArchitecture.Domain.Common
             }
 
             var other = (ValueObject)obj;
-            var thisValues = GetAtomicValues().GetEnumerator();
-            var otherValues = other.GetAtomicValues().GetEnumerator();
-
-            while (thisValues.MoveNext() && otherValues.MoveNext())
-            {
-                if (thisValues.Current is null ^ otherValues.Current is null)
-                {
-                    return false;
-                }
-
-                if (thisValues.Current != null &&
-                    !thisValues.Current.Equals(otherValues.Current))
-                {
-                    return false;
-                }
-            }
-
-            return !thisValues.MoveNext() && !otherValues.MoveNext();
+            return GetEqualityComponents().SequenceEqual(other.GetEqualityComponents());
         }
 
         public override int GetHashCode()
         {
-            return GetAtomicValues()
+            return GetEqualityComponents()
                 .Select(x => x != null ? x.GetHashCode() : 0)
                 .Aggregate((x, y) => x ^ y);
         }

--- a/src/Domain/ValueObjects/AdAccount.cs
+++ b/src/Domain/ValueObjects/AdAccount.cs
@@ -48,7 +48,7 @@ namespace CleanArchitecture.Domain.ValueObjects
             return $"{Domain}\\{Name}";
         }
 
-        protected override IEnumerable<object> GetAtomicValues()
+        protected override IEnumerable<object> GetEqualityComponents()
         {
             yield return Domain;
             yield return Name;


### PR DESCRIPTION
Hi there!

The `ValueObject` implementation in eShopOnContainers was recently updated according to this PR: https://github.com/dotnet-architecture/eShopOnContainers/pull/1316.

This new implementation cuts down on some of the complex code by using `SequenceEqual()` & the method name was changed to make the intent clearer. The docs page linked to at the top of `ValueObject` has also been updated here: https://docs.microsoft.com/en-us/dotnet/architecture/microservices/microservice-ddd-cqrs-patterns/implement-value-objects#value-object-implementation-in-c

This PR just updates the implementation of `ValueObject` & updates the one method call to `GetEqualityComponents()`