### PR TITLE
Mapping test should handle entities without parameterless constructor

### DIFF
--- a/tests/Application.UnitTests/Common/Mappings/MappingTests.cs
+++ b/tests/Application.UnitTests/Common/Mappings/MappingTests.cs
@@ -33,7 +33,16 @@ namespace CleanArchitecture.Application.UnitTests.Common.Mappings
         [TestCase(typeof(TodoItem), typeof(TodoItemDto))]
         public void ShouldSupportMappingFromSourceToDestination(Type source, Type destination)
         {
-            var instance = Activator.CreateInstance(source);
+            object instance;
+            try
+            {
+                instance = Activator.CreateInstance(source);
+            }
+            catch (MissingMethodException e)
+            {
+                instance = System.Runtime.Serialization.FormatterServices
+                    .GetUninitializedObject(source);
+            }
 
             _mapper.Map(instance, source, destination);
         }


### PR DESCRIPTION
It is oftentimes the case, that You don't allow entities with parameterless constructor in Your project to prevent developers for creating invalid entities. I found mapping test very elegant and I see a benefit for other developers, which might wanna use them in their projects.

GetUninitialized method creates an instance of an object and set all fields to default value, but do not call any of constructors. So mapping tests are still valid, but we skip any constructor-related issues if we cannot or don't have access to parameterless constructor