### PR TITLE
Fix DispatchEvents() that caused an infinite loop of events

### DIFF
--- a/src/Domain/Common/DomainEvent.cs
+++ b/src/Domain/Common/DomainEvent.cs
@@ -14,7 +14,7 @@ namespace CleanArchitecture.Domain.Common
         {
             DateOccurred = DateTimeOffset.UtcNow;
         }
-
+        public bool IsPublished { get; set; }
         public DateTimeOffset DateOccurred { get; protected set; } = DateTime.UtcNow;
     }
 }

--- a/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -72,10 +72,12 @@ namespace CleanArchitecture.Infrastructure.Persistence
             var domainEventEntities = ChangeTracker.Entries<IHasDomainEvent>()
                 .Select(x => x.Entity.DomainEvents)
                 .SelectMany(x => x)
+                .Where(domainEvent => !domainEvent.IsPublished)
                 .ToArray();
 
             foreach (var domainEvent in domainEventEntities)
             {
+                domainEvent.IsPublished = true;
                 await _domainEventService.Publish(domainEvent);
             }
         }


### PR DESCRIPTION
In case there's a domain event handler that's also triggering another domain event, it will enter an infinite loop.

To fix this, I am checking if the domain event has already been fired after its initialization.

