### PR TITLE
Provide enum values

### DIFF
--- a/src/Domain/Enums/PriorityLevel.cs
+++ b/src/Domain/Enums/PriorityLevel.cs
@@ -2,9 +2,9 @@
 {
     public enum PriorityLevel
     {
-        None,
-        Low,
-        Medium,
-        High
+        None = 0,
+        Low = 1,
+        Medium = 2,
+        High = 3
     }
 }


### PR DESCRIPTION
It is very common to discover that you need to add values to an enum after you have already shipped it. There is a potential application compatibility problem when the newly added value is returned from an existing API, because poorly written applications might not handle the new value correctly.