### PR TITLE
.Net 5 Fixed Build issue caused by  Nswag MSBuild  runtime variable configuration 

### DIFF
--- a/src/WebUI/WebUI.csproj
+++ b/src/WebUI/WebUI.csproj
@@ -45,7 +45,7 @@
 
   <Target Name="NSwag" AfterTargets="Build" Condition="'$(Configuration)' == 'Debug'">
     <Copy SourceFiles="@(Reference)" DestinationFolder="$(OutDir)References" />
-    <Exec Command="$(NSwagExe_Core31) run /variables:Configuration=$(Configuration)" />
+    <Exec Command="$(NSwagExe_Net50) run /variables:Configuration=$(Configuration)" />
     <RemoveDir Directories="$(OutDir)References" />
   </Target>
 

--- a/src/WebUI/nswag.json
+++ b/src/WebUI/nswag.json
@@ -1,5 +1,5 @@
 ﻿{
-  "runtime": "NetCore31",
+  "runtime": "Net50",
   "defaultVariables": null,
   "documentGenerator": {
     "aspNetCoreToOpenApi": {


### PR DESCRIPTION

The MSBuild  configurations for NSwagg command line was still trying to use Net core 3.1 runtime.
It was causing my builds to fail. The fix was to change the  $NSwagExe_31 variable  to $NSwagExe_50 to 
For more information you can visit [NSwag.MSBuild](https://github.com/RicoSuter/NSwag/wiki/NSwag.MSBuild) 🙂