### PR TITLE
use routing module for main app module

### DIFF
--- a/src/WebUI/ClientApp/src/app/app-routing.module.ts
+++ b/src/WebUI/ClientApp/src/app/app-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { AuthorizeGuard } from 'src/api-authorization/authorize.guard';
+import { CounterComponent } from './counter/counter.component';
+import { FetchDataComponent } from './fetch-data/fetch-data.component';
+import { HomeComponent } from './home/home.component';
+import { TodoComponent } from './todo/todo.component';
+
+export const routes: Routes = [
+
+  { path: 'counter', component: CounterComponent },
+  { path: 'fetch-data', component: FetchDataComponent },
+  { path: '', component: HomeComponent, pathMatch: 'full' },
+  { path: 'todo', component: TodoComponent, canActivate: [AuthorizeGuard] },
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes)],
+  exports: [RouterModule],
+})
+export class AppRoutingModule {}

--- a/src/WebUI/ClientApp/src/app/app.module.ts
+++ b/src/WebUI/ClientApp/src/app/app.module.ts
@@ -2,7 +2,6 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
-import { RouterModule } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 import { AppComponent } from './app.component';
@@ -12,10 +11,10 @@ import { CounterComponent } from './counter/counter.component';
 import { FetchDataComponent } from './fetch-data/fetch-data.component';
 import { TodoComponent } from './todo/todo.component';
 import { ApiAuthorizationModule } from 'src/api-authorization/api-authorization.module';
-import { AuthorizeGuard } from 'src/api-authorization/authorize.guard';
 import { AuthorizeInterceptor } from 'src/api-authorization/authorize.interceptor';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ModalModule } from 'ngx-bootstrap/modal';
+import { AppRoutingModule } from './app-routing.module';
 
 @NgModule({
   declarations: [
@@ -32,12 +31,7 @@ import { ModalModule } from 'ngx-bootstrap/modal';
     HttpClientModule,
     FormsModule,
     ApiAuthorizationModule,
-    RouterModule.forRoot([
-      { path: '', component: HomeComponent, pathMatch: 'full' },
-      { path: 'counter', component: CounterComponent },
-      { path: 'fetch-data', component: FetchDataComponent },
-      { path: 'todo', component: TodoComponent, canActivate: [AuthorizeGuard] },
-    ]),
+    AppRoutingModule,
     BrowserAnimationsModule,
     ModalModule.forRoot()
   ],


### PR DESCRIPTION
Hello,

this is my first public pull request so forgive me if I get something wrong.

I moved the routing paths from the app.module file into a separate app-routing.module.ts file as that is likely what every developer will do once the app has more than a couple routes.  Its also best practice according to[ angular.io. ](https://angular.io/guide/router) 
One final benefit is if you try to add something like nativescript, it can better discover the existing routes when creating the new nativescript code sharing project.

This is a preference change and does not change app functionality so integrate it if you like

Cheers

