### PR TITLE
Dispatch domain events from a behaviour

### DIFF
--- a/src/Application/Common/Behaviours/DomainEventPublishingBehavior.cs
+++ b/src/Application/Common/Behaviours/DomainEventPublishingBehavior.cs
@@ -1,0 +1,46 @@
+﻿using CleanArchitecture.Application.Common.Interfaces;
+using CleanArchitecture.Domain.Common;
+using MediatR.Pipeline;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CleanArchitecture.Application.Common.Behaviours
+{
+    public class DomainEventPublishingBehaviour<TRequest, TResponse> : IRequestPostProcessor<TRequest, TResponse>
+    {
+        private readonly ILogger _logger;
+        private readonly IApplicationDbContext _dbContext;
+        private readonly IDomainEventService _domainEventService;
+
+        public DomainEventPublishingBehaviour(
+            ILogger<TRequest> logger,
+            IApplicationDbContext dbContext,
+            IDomainEventService domainEventService)
+        {
+            _logger = logger;
+            _dbContext = dbContext;
+            _domainEventService = domainEventService;
+        }
+
+        public async Task Process(TRequest request, TResponse response, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                var domainEventEntity = _dbContext.ChangeTracker.Entries<IHasDomainEvent>()
+                                                     .Select(x => x.Entity.DomainEvents)
+                                                     .SelectMany(x => x)
+                                                     .Where(domainEvent => !domainEvent.IsPublished)
+                                                     .FirstOrDefault();
+                if (domainEventEntity == null) break;
+
+                domainEventEntity.IsPublished = true;
+                await _domainEventService.Publish(domainEventEntity);
+                
+                _logger.LogInformation("Published event: {Name}", domainEventEntity.GetType().Name);
+            }
+        }
+    }
+}

--- a/src/Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/Application/Common/Interfaces/IApplicationDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using CleanArchitecture.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,6 +12,7 @@ namespace CleanArchitecture.Application.Common.Interfaces
 
         DbSet<TodoItem> TodoItems { get; set; }
 
+        ChangeTracker ChangeTracker { get; }
         Task<int> SaveChangesAsync(CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
As suggested by @GFoley83 in #242, I removed domain event dispatching from the db context and instead created a pipeline behaviour that runs after requests to do it