### PR TITLE
Use `record` instead of `class` for ValueObject

### DIFF
--- a/src/Domain/Common/ValueObject.cs
+++ b/src/Domain/Common/ValueObject.cs
@@ -1,44 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-
-namespace CleanArchitecture.Domain.Common
+﻿namespace CleanArchitecture.Domain.Common
 {
-    // Learn more: https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/microservice-ddd-cqrs-patterns/implement-value-objects
-    public abstract class ValueObject
+    public abstract record ValueObject
     {
-        protected static bool EqualOperator(ValueObject left, ValueObject right)
-        {
-            if (left is null ^ right is null)
-            {
-                return false;
-            }
-
-            return left?.Equals(right) != false;
-        }
-
-        protected static bool NotEqualOperator(ValueObject left, ValueObject right)
-        {
-            return !(EqualOperator(left, right));
-        }
-
-        protected abstract IEnumerable<object> GetEqualityComponents();
-
-        public override bool Equals(object obj)
-        {
-            if (obj == null || obj.GetType() != GetType())
-            {
-                return false;
-            }
-
-            var other = (ValueObject)obj;
-            return GetEqualityComponents().SequenceEqual(other.GetEqualityComponents());
-        }
-
-        public override int GetHashCode()
-        {
-            return GetEqualityComponents()
-                .Select(x => x != null ? x.GetHashCode() : 0)
-                .Aggregate((x, y) => x ^ y);
-        }
     }
 }

--- a/src/Domain/ValueObjects/Colour.cs
+++ b/src/Domain/ValueObjects/Colour.cs
@@ -1,16 +1,12 @@
-﻿using CleanArchitecture.Domain.Common;
-using CleanArchitecture.Domain.Exceptions;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
+using CleanArchitecture.Domain.Common;
+using CleanArchitecture.Domain.Exceptions;
 
 namespace CleanArchitecture.Domain.ValueObjects
 {
-    public class Colour : ValueObject
+    public record Colour : ValueObject
     {
-        static Colour()
-        {
-        }
-
         private Colour()
         {
         }
@@ -22,7 +18,7 @@ namespace CleanArchitecture.Domain.ValueObjects
 
         public static Colour From(string code)
         {
-            var colour = new Colour { Code = code };
+            var colour = new Colour {Code = code};
 
             if (!SupportedColours.Contains(colour))
             {
@@ -78,11 +74,6 @@ namespace CleanArchitecture.Domain.ValueObjects
                 yield return Purple;
                 yield return Grey;
             }
-        }
-
-        protected override IEnumerable<object> GetEqualityComponents()
-        {
-            yield return Code;
         }
     }
 }


### PR DESCRIPTION
This takes advantage of the new `record` type that encapsulates value object equality.

Benefits
* No code in `ValueObject`
* Classes inheriting `ValueObject` (i.e. `Colour`) don't need to implement `IEnumerable<object> GetEqualityComponents()`