### PR TITLE
Make exceptions correctly implement ISerializable

### DIFF
--- a/src/Application/Common/Exceptions/ForbiddenAccessException.cs
+++ b/src/Application/Common/Exceptions/ForbiddenAccessException.cs
@@ -1,9 +1,16 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace CleanArchitecture.Application.Common.Exceptions
 {
+    [Serializable]
     public class ForbiddenAccessException : Exception
     {
         public ForbiddenAccessException() : base() { }
+
+        protected ForbiddenAccessException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 }

--- a/src/Application/Common/Exceptions/NotFoundException.cs
+++ b/src/Application/Common/Exceptions/NotFoundException.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace CleanArchitecture.Application.Common.Exceptions
 {
+    [Serializable]
     public class NotFoundException : Exception
     {
         public NotFoundException()
@@ -21,6 +23,11 @@ namespace CleanArchitecture.Application.Common.Exceptions
 
         public NotFoundException(string name, object key)
             : base($"Entity \"{name}\" ({key}) was not found.")
+        {
+        }
+
+        protected NotFoundException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/Application/Common/Exceptions/ValidationException.cs
+++ b/src/Application/Common/Exceptions/ValidationException.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using FluentValidation.Results;
 
 namespace CleanArchitecture.Application.Common.Exceptions
 {
+    [Serializable]
     public class ValidationException : Exception
     {
         public ValidationException()
@@ -22,5 +24,20 @@ namespace CleanArchitecture.Application.Common.Exceptions
         }
 
         public IDictionary<string, string[]> Errors { get; }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue("Errors", Errors);
+        }
+
+        protected ValidationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            if (info == null)
+                throw new ArgumentNullException(nameof(info));
+
+            Errors = (Dictionary<string, string[]>)info.GetValue("Errors", typeof(Dictionary<string,string[]>));
+        }
     }
 }

--- a/tests/Application.UnitTests/Common/Exceptions/ForbiddenAccessExceptionTests.cs
+++ b/tests/Application.UnitTests/Common/Exceptions/ForbiddenAccessExceptionTests.cs
@@ -1,0 +1,15 @@
+﻿using CleanArchitecture.Application.Common.Exceptions;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace CleanArchitecture.Application.UnitTests.Common.Exceptions
+{
+    public class ForbiddenAccessExceptionTests
+    {
+        [Test]
+        public void ShouldBeSerializable()
+        {
+            new ForbiddenAccessException().Should().BeBinarySerializable();
+        }
+    }
+}

--- a/tests/Application.UnitTests/Common/Exceptions/NotFoundExceptionTests.cs
+++ b/tests/Application.UnitTests/Common/Exceptions/NotFoundExceptionTests.cs
@@ -1,0 +1,15 @@
+﻿using CleanArchitecture.Application.Common.Exceptions;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace CleanArchitecture.Application.UnitTests.Common.Exceptions
+{
+    public class NotFoundExceptionTests
+    {
+        [Test]
+        public void ShouldBeBinarySerializable()
+        {
+            new NotFoundException("EntityName", 1).Should().BeBinarySerializable();
+        }
+    }
+}

--- a/tests/Application.UnitTests/Common/Exceptions/NotFoundExceptionTests.cs
+++ b/tests/Application.UnitTests/Common/Exceptions/NotFoundExceptionTests.cs
@@ -7,7 +7,7 @@ namespace CleanArchitecture.Application.UnitTests.Common.Exceptions
     public class NotFoundExceptionTests
     {
         [Test]
-        public void ShouldBeBinarySerializable()
+        public void ShouldBeSerializable()
         {
             new NotFoundException("EntityName", 1).Should().BeBinarySerializable();
         }

--- a/tests/Application.UnitTests/Common/Exceptions/ValidationExceptionTests.cs
+++ b/tests/Application.UnitTests/Common/Exceptions/ValidationExceptionTests.cs
@@ -48,19 +48,35 @@ namespace CleanArchitecture.Application.UnitTests.Common.Exceptions
 
             actual.Keys.Should().BeEquivalentTo(new string[] { "Password", "Age" });
 
-            actual["Age"].Should().BeEquivalentTo(new string[] 
-            { 
-                "must be 25 or younger", 
+            actual["Age"].Should().BeEquivalentTo(new string[]
+            {
+                "must be 25 or younger",
                 "must be 18 or older",
             });
 
-            actual["Password"].Should().BeEquivalentTo(new string[] 
-            { 
+            actual["Password"].Should().BeEquivalentTo(new string[]
+            {
                 "must contain lower case letter",
                 "must contain upper case letter",
                 "must contain at least 8 characters",
                 "must contain a digit",
             });
+        }
+
+        [Test]
+        public void ShouldBeSerializable()
+        {
+            var failures = new List<ValidationFailure>
+            {
+                new ValidationFailure("Age", "must be 18 or older"),
+                new ValidationFailure("Age", "must be 25 or younger"),
+                new ValidationFailure("Password", "must contain at least 8 characters"),
+                new ValidationFailure("Password", "must contain a digit"),
+                new ValidationFailure("Password", "must contain upper case letter"),
+                new ValidationFailure("Password", "must contain lower case letter"),
+            };
+
+            new ValidationException(failures).Should().BeBinarySerializable();
         }
     }
 }


### PR DESCRIPTION
## Make exceptions correctly implement ISerializable

The base **Exception** class implements _ISerializable_ and is marked with the [Serializable] annotation.

Custom exceptions, inheriting from **Exception**, should also be marked as [Serializable] and must correctly implement the _ISerializable_ interface.

A few simple tests have been added to check that these three custom exceptions can indeed be correctly serialized and deserialized (binary serialization).

### References

- Microsoft Docs [ISerializable documentation for .NET 5](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.iserializable?view=net-5.0)
- SonarLint Specification: [Rule RSPEC-3925](https://jira.sonarsource.com/browse/RSPEC-3925)
- Not implementing ISerializable properly is a violation of the [Liskov substitution principle](https://en.wikipedia.org/wiki/Liskov_substitution_principle) 

