### PR TITLE
Replace all commands and queries to be records

### DIFF
--- a/src/Application/TodoItems/Commands/CreateTodoItem/CreateTodoItemCommand.cs
+++ b/src/Application/TodoItems/Commands/CreateTodoItem/CreateTodoItemCommand.cs
@@ -7,12 +7,7 @@ using System.Threading.Tasks;
 
 namespace CleanArchitecture.Application.TodoItems.Commands.CreateTodoItem
 {
-    public class CreateTodoItemCommand : IRequest<int>
-    {
-        public int ListId { get; set; }
-
-        public string Title { get; set; }
-    }
+    public record CreateTodoItemCommand(int ListId, string Title) : IRequest<int>;
 
     public class CreateTodoItemCommandHandler : IRequestHandler<CreateTodoItemCommand, int>
     {

--- a/src/Application/TodoItems/Commands/DeleteTodoItem/DeleteTodoItemCommand.cs
+++ b/src/Application/TodoItems/Commands/DeleteTodoItem/DeleteTodoItemCommand.cs
@@ -7,10 +7,7 @@ using System.Threading.Tasks;
 
 namespace CleanArchitecture.Application.TodoItems.Commands.DeleteTodoItem
 {
-    public class DeleteTodoItemCommand : IRequest
-    {
-        public int Id { get; set; }
-    }
+    public record DeleteTodoItemCommand(int Id) : IRequest;
 
     public class DeleteTodoItemCommandHandler : IRequestHandler<DeleteTodoItemCommand>
     {

--- a/src/Application/TodoItems/Commands/UpdateTodoItem/UpdateTodoItemCommand.cs
+++ b/src/Application/TodoItems/Commands/UpdateTodoItem/UpdateTodoItemCommand.cs
@@ -7,14 +7,7 @@ using System.Threading.Tasks;
 
 namespace CleanArchitecture.Application.TodoItems.Commands.UpdateTodoItem
 {
-    public class UpdateTodoItemCommand : IRequest
-    {
-        public int Id { get; set; }
-
-        public string Title { get; set; }
-
-        public bool Done { get; set; }
-    }
+    public record UpdateTodoItemCommand(int Id, string Title, bool Done = false) : IRequest;
 
     public class UpdateTodoItemCommandHandler : IRequestHandler<UpdateTodoItemCommand>
     {

--- a/src/Application/TodoItems/Commands/UpdateTodoItemDetail/UpdateTodoItemDetailCommand.cs
+++ b/src/Application/TodoItems/Commands/UpdateTodoItemDetail/UpdateTodoItemDetailCommand.cs
@@ -8,16 +8,7 @@ using System.Threading.Tasks;
 
 namespace CleanArchitecture.Application.TodoItems.Commands.UpdateTodoItemDetail
 {
-    public class UpdateTodoItemDetailCommand : IRequest
-    {
-        public int Id { get; set; }
-
-        public int ListId { get; set; }
-
-        public PriorityLevel Priority { get; set; }
-
-        public string Note { get; set; }
-    }
+    public record UpdateTodoItemDetailCommand(int Id, int ListId, PriorityLevel Priority, string Note) : IRequest;
 
     public class UpdateTodoItemDetailCommandHandler : IRequestHandler<UpdateTodoItemDetailCommand>
     {

--- a/src/Application/TodoItems/Queries/GetTodoItemsWithPagination/GetTodoItemsWithPaginationQuery.cs
+++ b/src/Application/TodoItems/Queries/GetTodoItemsWithPagination/GetTodoItemsWithPaginationQuery.cs
@@ -11,12 +11,7 @@ using System.Threading.Tasks;
 
 namespace CleanArchitecture.Application.TodoItems.Queries.GetTodoItemsWithPagination
 {
-    public class GetTodoItemsWithPaginationQuery : IRequest<PaginatedList<TodoItemDto>>
-    {
-        public int ListId { get; set; }
-        public int PageNumber { get; set; } = 1;
-        public int PageSize { get; set; } = 10;
-    }
+    public record GetTodoItemsWithPaginationQuery(int ListId, int PageNumber = 1, int PageSize = 10): IRequest<PaginatedList<TodoItemDto>>;
 
     public class GetTodoItemsWithPaginationQueryHandler : IRequestHandler<GetTodoItemsWithPaginationQuery, PaginatedList<TodoItemDto>>
     {

--- a/src/Application/TodoLists/Commands/CreateTodoList/CreateTodoListCommand.cs
+++ b/src/Application/TodoLists/Commands/CreateTodoList/CreateTodoListCommand.cs
@@ -6,10 +6,7 @@ using System.Threading.Tasks;
 
 namespace CleanArchitecture.Application.TodoLists.Commands.CreateTodoList
 {
-    public class CreateTodoListCommand : IRequest<int>
-    {
-        public string Title { get; set; }
-    }
+    public record CreateTodoListCommand(string Title) : IRequest<int>;
 
     public class CreateTodoListCommandHandler : IRequestHandler<CreateTodoListCommand, int>
     {

--- a/src/Application/TodoLists/Commands/DeleteTodoList/DeleteTodoListCommand.cs
+++ b/src/Application/TodoLists/Commands/DeleteTodoList/DeleteTodoListCommand.cs
@@ -9,10 +9,7 @@ using System.Threading.Tasks;
 
 namespace CleanArchitecture.Application.TodoLists.Commands.DeleteTodoList
 {
-    public class DeleteTodoListCommand : IRequest
-    {
-        public int Id { get; set; }
-    }
+    public record DeleteTodoListCommand(int Id) : IRequest;
 
     public class DeleteTodoListCommandHandler : IRequestHandler<DeleteTodoListCommand>
     {

--- a/src/Application/TodoLists/Commands/PurgeTodoLists/PurgeTodoListsCommand.cs
+++ b/src/Application/TodoLists/Commands/PurgeTodoLists/PurgeTodoListsCommand.cs
@@ -8,9 +8,7 @@ namespace CleanArchitecture.Application.TodoLists.Commands.PurgeTodoLists
 {
     [Authorize(Roles = "Administrator")]
     [Authorize(Policy = "CanPurge")]
-    public class PurgeTodoListsCommand : IRequest
-    {
-    }
+    public record PurgeTodoListsCommand : IRequest;
 
     public class PurgeTodoListsCommandHandler : IRequestHandler<PurgeTodoListsCommand>
     {

--- a/src/Application/TodoLists/Commands/UpdateTodoList/UpdateTodoListCommand.cs
+++ b/src/Application/TodoLists/Commands/UpdateTodoList/UpdateTodoListCommand.cs
@@ -7,12 +7,7 @@ using System.Threading.Tasks;
 
 namespace CleanArchitecture.Application.TodoLists.Commands.UpdateTodoList
 {
-    public class UpdateTodoListCommand : IRequest
-    {
-        public int Id { get; set; }
-
-        public string Title { get; set; }
-    }
+    public record UpdateTodoListCommand(int Id, string Title) : IRequest;
 
     public class UpdateTodoListCommandHandler : IRequestHandler<UpdateTodoListCommand>
     {

--- a/src/Application/TodoLists/Queries/ExportTodos/ExportTodosQuery.cs
+++ b/src/Application/TodoLists/Queries/ExportTodos/ExportTodosQuery.cs
@@ -9,10 +9,7 @@ using System.Threading.Tasks;
 
 namespace CleanArchitecture.Application.TodoLists.Queries.ExportTodos
 {
-    public class ExportTodosQuery : IRequest<ExportTodosVm>
-    {
-        public int ListId { get; set; }
-    }
+    public record ExportTodosQuery(int ListId) : IRequest<ExportTodosVm>;
 
     public class ExportTodosQueryHandler : IRequestHandler<ExportTodosQuery, ExportTodosVm>
     {

--- a/src/Application/TodoLists/Queries/GetTodos/GetTodosQuery.cs
+++ b/src/Application/TodoLists/Queries/GetTodos/GetTodosQuery.cs
@@ -12,9 +12,7 @@ using System.Threading.Tasks;
 
 namespace CleanArchitecture.Application.TodoLists.Queries.GetTodos
 {
-    public class GetTodosQuery : IRequest<TodosVm>
-    {
-    }
+    public record GetTodosQuery : IRequest<TodosVm>;
 
     public class GetTodosQueryHandler : IRequestHandler<GetTodosQuery, TodosVm>
     {

--- a/src/Application/WeatherForecasts/Queries/GetWeatherForecasts/GetWeatherForecastsQuery.cs
+++ b/src/Application/WeatherForecasts/Queries/GetWeatherForecasts/GetWeatherForecastsQuery.cs
@@ -7,9 +7,7 @@ using System.Threading.Tasks;
 
 namespace CleanArchitecture.Application.WeatherForecasts.Queries.GetWeatherForecasts
 {
-    public class GetWeatherForecastsQuery : IRequest<IEnumerable<WeatherForecast>>
-    {
-    }
+    public record GetWeatherForecastsQuery : IRequest<IEnumerable<WeatherForecast>>;
 
     public class GetWeatherForecastsQueryHandler : IRequestHandler<GetWeatherForecastsQuery, IEnumerable<WeatherForecast>>
     {

--- a/src/WebUI/Controllers/TodoItemsController.cs
+++ b/src/WebUI/Controllers/TodoItemsController.cs
@@ -55,7 +55,7 @@ namespace CleanArchitecture.WebUI.Controllers
         [HttpDelete("{id}")]
         public async Task<ActionResult> Delete(int id)
         {
-            await Mediator.Send(new DeleteTodoItemCommand { Id = id });
+            await Mediator.Send(new DeleteTodoItemCommand(id));
 
             return NoContent();
         }

--- a/src/WebUI/Controllers/TodoListsController.cs
+++ b/src/WebUI/Controllers/TodoListsController.cs
@@ -21,7 +21,7 @@ namespace CleanArchitecture.WebUI.Controllers
         [HttpGet("{id}")]
         public async Task<FileResult> Get(int id)
         {
-            var vm = await Mediator.Send(new ExportTodosQuery { ListId = id });
+            var vm = await Mediator.Send(new ExportTodosQuery(id));
 
             return File(vm.Content, vm.ContentType, vm.FileName);
         }
@@ -48,7 +48,7 @@ namespace CleanArchitecture.WebUI.Controllers
         [HttpDelete("{id}")]
         public async Task<ActionResult> Delete(int id)
         {
-            await Mediator.Send(new DeleteTodoListCommand { Id = id });
+            await Mediator.Send(new DeleteTodoListCommand(id));
 
             return NoContent();
         }

--- a/tests/Application.IntegrationTests/TodoItems/Commands/CreateTodoItemTests.cs
+++ b/tests/Application.IntegrationTests/TodoItems/Commands/CreateTodoItemTests.cs
@@ -16,7 +16,7 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoItems.Commands
         [Test]
         public void ShouldRequireMinimumFields()
         {
-            var command = new CreateTodoItemCommand();
+            var command = new CreateTodoItemCommand(0, null);
 
             FluentActions.Invoking(() =>
                 SendAsync(command)).Should().Throw<ValidationException>();
@@ -27,16 +27,9 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoItems.Commands
         {
             var userId = await RunAsDefaultUserAsync();
 
-            var listId = await SendAsync(new CreateTodoListCommand
-            {
-                Title = "New List"
-            });
+            var listId = await SendAsync(new CreateTodoListCommand("New List"));
 
-            var command = new CreateTodoItemCommand
-            {
-                ListId = listId,
-                Title = "Tasks"
-            };
+            var command = new CreateTodoItemCommand(listId, "Tasks");
 
             var itemId = await SendAsync(command);
 

--- a/tests/Application.IntegrationTests/TodoItems/Commands/DeleteTodoItemTests.cs
+++ b/tests/Application.IntegrationTests/TodoItems/Commands/DeleteTodoItemTests.cs
@@ -16,7 +16,7 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoItems.Commands
         [Test]
         public void ShouldRequireValidTodoItemId()
         {
-            var command = new DeleteTodoItemCommand { Id = 99 };
+            var command = new DeleteTodoItemCommand(99);
 
             FluentActions.Invoking(() =>
                 SendAsync(command)).Should().Throw<NotFoundException>();
@@ -25,21 +25,11 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoItems.Commands
         [Test]
         public async Task ShouldDeleteTodoItem()
         {
-            var listId = await SendAsync(new CreateTodoListCommand
-            {
-                Title = "New List"
-            });
+            var listId = await SendAsync(new CreateTodoListCommand("New List"));
 
-            var itemId = await SendAsync(new CreateTodoItemCommand
-            {
-                ListId = listId,
-                Title = "New Item"
-            });
+            var itemId = await SendAsync(new CreateTodoItemCommand(listId, "New Item"));
 
-            await SendAsync(new DeleteTodoItemCommand
-            {
-                Id = itemId
-            });
+            await SendAsync(new DeleteTodoItemCommand(itemId));
 
             var list = await FindAsync<TodoItem>(listId);
 

--- a/tests/Application.IntegrationTests/TodoItems/Commands/UpdateTodoItemDetailTests.cs
+++ b/tests/Application.IntegrationTests/TodoItems/Commands/UpdateTodoItemDetailTests.cs
@@ -19,11 +19,7 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoItems.Commands
         [Test]
         public void ShouldRequireValidTodoItemId()
         {
-            var command = new UpdateTodoItemCommand
-            {
-                Id = 99,
-                Title = "New Title"
-            };
+            var command = new UpdateTodoItemCommand(99, "New Title");
 
             FluentActions.Invoking(() =>
                 SendAsync(command)).Should().Throw<NotFoundException>();
@@ -34,24 +30,11 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoItems.Commands
         {
             var userId = await RunAsDefaultUserAsync();
 
-            var listId = await SendAsync(new CreateTodoListCommand
-            {
-                Title = "New List"
-            });
+            var listId = await SendAsync(new CreateTodoListCommand("New List"));
 
-            var itemId = await SendAsync(new CreateTodoItemCommand
-            {
-                ListId = listId,
-                Title = "New Item"
-            });
+            var itemId = await SendAsync(new CreateTodoItemCommand(listId, "New Item"));
 
-            var command = new UpdateTodoItemDetailCommand
-            {
-                Id = itemId,
-                ListId = listId,
-                Note = "This is the note.",
-                Priority = PriorityLevel.High
-            };
+            var command = new UpdateTodoItemDetailCommand(itemId, listId, PriorityLevel.High, "This is the note.");
 
             await SendAsync(command);
 

--- a/tests/Application.IntegrationTests/TodoItems/Commands/UpdateTodoItemTests.cs
+++ b/tests/Application.IntegrationTests/TodoItems/Commands/UpdateTodoItemTests.cs
@@ -17,11 +17,7 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoItems.Commands
         [Test]
         public void ShouldRequireValidTodoItemId()
         {
-            var command = new UpdateTodoItemCommand
-            {
-                Id = 99,
-                Title = "New Title"
-            };
+            var command = new UpdateTodoItemCommand(99, "New Title");
 
             FluentActions.Invoking(() =>
                 SendAsync(command)).Should().Throw<NotFoundException>();
@@ -32,22 +28,11 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoItems.Commands
         {
             var userId = await RunAsDefaultUserAsync();
 
-            var listId = await SendAsync(new CreateTodoListCommand
-            {
-                Title = "New List"
-            });
+            var listId = await SendAsync(new CreateTodoListCommand("New List"));
 
-            var itemId = await SendAsync(new CreateTodoItemCommand
-            {
-                ListId = listId,
-                Title = "New Item"
-            });
+            var itemId = await SendAsync(new CreateTodoItemCommand(listId, "New Item"));
 
-            var command = new UpdateTodoItemCommand
-            {
-                Id = itemId,
-                Title = "Updated Item Title"
-            };
+            var command = new UpdateTodoItemCommand(itemId, "Updated Item Title");
 
             await SendAsync(command);
 

--- a/tests/Application.IntegrationTests/TodoLists/Commands/CreateTodoListTests.cs
+++ b/tests/Application.IntegrationTests/TodoLists/Commands/CreateTodoListTests.cs
@@ -15,7 +15,7 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoLists.Commands
         [Test]
         public void ShouldRequireMinimumFields()
         {
-            var command = new CreateTodoListCommand();
+            var command = new CreateTodoListCommand(null);
 
             FluentActions.Invoking(() =>
                 SendAsync(command)).Should().Throw<ValidationException>();
@@ -24,15 +24,9 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoLists.Commands
         [Test]
         public async Task ShouldRequireUniqueTitle()
         {
-            await SendAsync(new CreateTodoListCommand
-            {
-                Title = "Shopping"
-            });
+            await SendAsync(new CreateTodoListCommand("Shopping"));
 
-            var command = new CreateTodoListCommand
-            {
-                Title = "Shopping"
-            };
+            var command = new CreateTodoListCommand("Shopping");
 
             FluentActions.Invoking(() =>
                 SendAsync(command)).Should().Throw<ValidationException>();
@@ -43,10 +37,7 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoLists.Commands
         {
             var userId = await RunAsDefaultUserAsync();
 
-            var command = new CreateTodoListCommand
-            {
-                Title = "Tasks"
-            };
+            var command = new CreateTodoListCommand("Tasks");
 
             var id = await SendAsync(command);
 

--- a/tests/Application.IntegrationTests/TodoLists/Commands/DeleteTodoListTests.cs
+++ b/tests/Application.IntegrationTests/TodoLists/Commands/DeleteTodoListTests.cs
@@ -15,7 +15,7 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoLists.Commands
         [Test]
         public void ShouldRequireValidTodoListId()
         {
-            var command = new DeleteTodoListCommand { Id = 99 };
+            var command = new DeleteTodoListCommand(99);
 
             FluentActions.Invoking(() =>
                 SendAsync(command)).Should().Throw<NotFoundException>();
@@ -24,15 +24,9 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoLists.Commands
         [Test]
         public async Task ShouldDeleteTodoList()
         {
-            var listId = await SendAsync(new CreateTodoListCommand
-            {
-                Title = "New List"
-            });
+            var listId = await SendAsync(new CreateTodoListCommand("New List"));
 
-            await SendAsync(new DeleteTodoListCommand 
-            { 
-                Id = listId 
-            });
+            await SendAsync(new DeleteTodoListCommand(listId));
 
             var list = await FindAsync<TodoList>(listId);
 

--- a/tests/Application.IntegrationTests/TodoLists/Commands/PurgeTodoListsTests.cs
+++ b/tests/Application.IntegrationTests/TodoLists/Commands/PurgeTodoListsTests.cs
@@ -53,20 +53,11 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoLists.Commands
         {
             await RunAsAdministratorAsync();
 
-            await SendAsync(new CreateTodoListCommand
-            {
-                Title = "New List #1"
-            });
+            await SendAsync(new CreateTodoListCommand("New List #1"));
 
-            await SendAsync(new CreateTodoListCommand
-            {
-                Title = "New List #2"
-            });
+            await SendAsync(new CreateTodoListCommand("New List #2"));
 
-            await SendAsync(new CreateTodoListCommand
-            {
-                Title = "New List #3"
-            });
+            await SendAsync(new CreateTodoListCommand("New List #3"));
 
             await SendAsync(new PurgeTodoListsCommand());
 

--- a/tests/Application.IntegrationTests/TodoLists/Commands/UpdateTodoListTests.cs
+++ b/tests/Application.IntegrationTests/TodoLists/Commands/UpdateTodoListTests.cs
@@ -16,11 +16,7 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoLists.Commands
         [Test]
         public void ShouldRequireValidTodoListId()
         {
-            var command = new UpdateTodoListCommand
-            {
-                Id = 99,
-                Title = "New Title"
-            };
+            var command = new UpdateTodoListCommand(99, "New Title");
 
             FluentActions.Invoking(() =>
                 SendAsync(command)).Should().Throw<NotFoundException>();
@@ -29,21 +25,11 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoLists.Commands
         [Test]
         public async Task ShouldRequireUniqueTitle()
         {
-            var listId = await SendAsync(new CreateTodoListCommand
-            {
-                Title = "New List"
-            });
+            var listId = await SendAsync(new CreateTodoListCommand("New List"));
 
-            await SendAsync(new CreateTodoListCommand
-            {
-                Title = "Other List"
-            });
+            await SendAsync(new CreateTodoListCommand("Other List"));
 
-            var command = new UpdateTodoListCommand
-            {
-                Id = listId,
-                Title = "Other List"
-            };
+            var command = new UpdateTodoListCommand(listId, "Other List");
 
             FluentActions.Invoking(() =>
                 SendAsync(command))
@@ -56,16 +42,9 @@ namespace CleanArchitecture.Application.IntegrationTests.TodoLists.Commands
         {
             var userId = await RunAsDefaultUserAsync();
 
-            var listId = await SendAsync(new CreateTodoListCommand
-            {
-                Title = "New List"
-            });
+            var listId = await SendAsync(new CreateTodoListCommand("New List"));
 
-            var command = new UpdateTodoListCommand
-            {
-                Id = listId,
-                Title = "Updated List Title"
-            };
+            var command = new UpdateTodoListCommand(listId, "Updated List Title");
 
             await SendAsync(command);
 

--- a/tests/Application.UnitTests/Common/Behaviours/RequestLoggerTests.cs
+++ b/tests/Application.UnitTests/Common/Behaviours/RequestLoggerTests.cs
@@ -32,7 +32,7 @@ namespace CleanArchitecture.Application.UnitTests.Common.Behaviours
 
             var requestLogger = new LoggingBehaviour<CreateTodoItemCommand>(_logger.Object, _currentUserService.Object, _identityService.Object);
 
-            await requestLogger.Process(new CreateTodoItemCommand { ListId = 1, Title = "title" }, new CancellationToken());
+            await requestLogger.Process(new CreateTodoItemCommand(1, "title"), new CancellationToken());
 
             _identityService.Verify(i => i.GetUserNameAsync(It.IsAny<string>()), Times.Once);
         }
@@ -42,7 +42,7 @@ namespace CleanArchitecture.Application.UnitTests.Common.Behaviours
         {
             var requestLogger = new LoggingBehaviour<CreateTodoItemCommand>(_logger.Object, _currentUserService.Object, _identityService.Object);
 
-            await requestLogger.Process(new CreateTodoItemCommand { ListId = 1, Title = "title" }, new CancellationToken());
+            await requestLogger.Process(new CreateTodoItemCommand(1, "title"), new CancellationToken());
 
             _identityService.Verify(i => i.GetUserNameAsync(null), Times.Never);
         }


### PR DESCRIPTION
Based on the #347 and the discussion in #314 

This PR only applies to the commands and queries and does not change anything else.

The pros: 

* Shorter code
* Commands/Queries definitely fit the requirements to be records
* Can explicitly say what is required and what is optional

The cons:

* Readability is slightly lower since you can't read what is the property assigned directly by looking. (`new Command { Name = "Something" }` vs `new Command("Something")` )
* The user of this template might misunderstand that all commands/queries must be records which is not the case

