### PR TITLE
Removed string typename and support for more interfaces

### DIFF
--- a/src/Application/Common/Mappings/MappingProfile.cs
+++ b/src/Application/Common/Mappings/MappingProfile.cs
@@ -14,19 +14,40 @@ namespace CleanArchitecture.Application.Common.Mappings
 
         private void ApplyMappingsFromAssembly(Assembly assembly)
         {
-            var types = assembly.GetExportedTypes()
-                .Where(t => t.GetInterfaces().Any(i => 
-                    i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IMapFrom<>)))
-                .ToList();
+            var mapFromType = typeof(IMapFrom<>);
+            
+            var mappingMethodName = nameof(IMapFrom<object>.Mapping);
+
+            bool HasInterface(Type t) => t.IsGenericType && t.GetGenericTypeDefinition() == mapFromType;
+            
+            var types = assembly.GetExportedTypes().Where(t => t.GetInterfaces().Any(HasInterfaces)).ToList();
+            
+            var argumentTypes = new Type[] { typeof(Profile) };
 
             foreach (var type in types)
             {
                 var instance = Activator.CreateInstance(type);
-
-                var methodInfo = type.GetMethod("Mapping") 
-                    ?? type.GetInterface("IMapFrom`1").GetMethod("Mapping");
                 
-                methodInfo?.Invoke(instance, new object[] { this });
+                var methodInfo = type.GetMethod(mappingMethodName);
+
+                if (methodInfo != null)
+                {
+                    methodInfo.Invoke(instance, new object[] { this });
+                }
+                else
+                {
+                    var interfaces = type.GetInterfaces().Where(HasInterface).ToList();
+
+                    if (interfaces.Count > 0)
+                    {
+                        foreach (var @interface in interfaces)
+                        {
+                            var interfaceMethodInfo = @interface.GetMethod(mappingMethodName, argumentTypes);
+
+                            interfaceMethodInfo?.Invoke(instance, new object[] { this });
+                        }
+                    }
+                }
 
             }
         }


### PR DESCRIPTION
Hi @jasontaylordev !

This PR replaces the string type names with the interface type.
And it supports multiple interfaces.