### PR TITLE
Changed 'pageIndex' variable name to 'pageNumber' in PaginatedList.cs

### DIFF
--- a/src/Application/Common/Models/PaginatedList.cs
+++ b/src/Application/Common/Models/PaginatedList.cs
@@ -9,28 +9,28 @@ namespace CleanArchitecture.Application.Common.Models
     public class PaginatedList<T> 
     {
         public List<T> Items { get; }
-        public int PageIndex { get; }
+        public int PageNumber { get; }
         public int TotalPages { get; }
         public int TotalCount { get; }
 
-        public PaginatedList(List<T> items, int count, int pageIndex, int pageSize)
+        public PaginatedList(List<T> items, int count, int pageNumber, int pageSize)
         {
-            PageIndex = pageIndex;
+            PageNumber = pageNumber;
             TotalPages = (int)Math.Ceiling(count / (double)pageSize);
             TotalCount = count;
             Items = items;
         }
 
-        public bool HasPreviousPage => PageIndex > 1;
+        public bool HasPreviousPage => PageNumber > 1;
 
-        public bool HasNextPage => PageIndex < TotalPages;
+        public bool HasNextPage => PageNumber < TotalPages;
 
-        public static async Task<PaginatedList<T>> CreateAsync(IQueryable<T> source, int pageIndex, int pageSize)
+        public static async Task<PaginatedList<T>> CreateAsync(IQueryable<T> source, int pageNumber, int pageSize)
         {
             var count = await source.CountAsync();
-            var items = await source.Skip((pageIndex - 1) * pageSize).Take(pageSize).ToListAsync();
+            var items = await source.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToListAsync();
 
-            return new PaginatedList<T>(items, count, pageIndex, pageSize);
+            return new PaginatedList<T>(items, count, pageNumber, pageSize);
         }
     }
 }


### PR DESCRIPTION
Hi @jasontaylordev !

This simple PR replaces the variable name from "PageIndex" to "PageNumber" as it should start from 1, not 0. Also in GetTodoItemsWithPaginationQuery.cs class, it creates pageNumber and passes to PaginatedList.cs.