### PR TITLE
Add <ApplicationDbContext> to DbContextOptions parameter on ApplicationDbContext constructor

### DIFF
--- a/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -20,7 +20,7 @@ namespace CleanArchitecture.Infrastructure.Persistence
         private readonly IDomainEventService _domainEventService;
 
         public ApplicationDbContext(
-            DbContextOptions options,
+            DbContextOptions<ApplicationDbContext> options,
             IOptions<OperationalStoreOptions> operationalStoreOptions,
             ICurrentUserService currentUserService,
             IDomainEventService domainEventService,


### PR DESCRIPTION
In order to avoid the exception: "The DbContextOptions passed to the ApplicationDbContext constructor must be a DbContextOptions<ApplicationDbContext>. When registering multiple DbContext types, make sure that the constructor for each context type has a DbContextOptions<TContext> parameter rather than a non-generic DbContextOptions parameter."