### PR TITLE
Solve the problem of publishing deleted events

### DIFF
--- a/src/Application/TodoItems/Commands/DeleteTodoItem/DeleteTodoItemCommand.cs
+++ b/src/Application/TodoItems/Commands/DeleteTodoItem/DeleteTodoItemCommand.cs
@@ -1,6 +1,7 @@
 ﻿using CleanArchitecture.Application.Common.Exceptions;
 using CleanArchitecture.Application.Common.Interfaces;
 using CleanArchitecture.Domain.Entities;
+using CleanArchitecture.Domain.Events;
 using MediatR;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,6 +32,8 @@ namespace CleanArchitecture.Application.TodoItems.Commands.DeleteTodoItem
             }
 
             _context.TodoItems.Remove(entity);
+
+            entity.DomainEvents.Add(new TodoItemDeletedEvent(entity));
 
             await _context.SaveChangesAsync(cancellationToken);
 

--- a/src/Domain/Events/TodoItemDeletedEvent.cs
+++ b/src/Domain/Events/TodoItemDeletedEvent.cs
@@ -1,0 +1,15 @@
+﻿using CleanArchitecture.Domain.Common;
+using CleanArchitecture.Domain.Entities;
+
+namespace CleanArchitecture.Domain.Events
+{
+    public class TodoItemDeletedEvent : DomainEvent
+    {
+        public TodoItemDeletedEvent(TodoItem item)
+        {
+            Item = item;
+        }
+
+        public TodoItem Item { get; }
+    }
+}


### PR DESCRIPTION
### I found a bug when publish event delete a entity 

Suppose you want an event to be published at the same time when a "TodoItem" is deleted ex:

> ...
> entity.DomainEvents.Add(new TodoItemDeletedEvent(entity));
> ...

**This event will not be published!**

This is because "ChangeTracker" in "EFCore" after calling
> var result = await base.SaveChangesAsync(cancellationToken);

Removes all deleted changes from the "ChangeTracker" history, leaving event output empty.
That's why we need to save the events before clearing "ChangeTracker" so that we can publish the events after applying the changes to the database.

So we will have:
```
var events = ChangeTracker.Entries<IHasDomainEvent>()
                    .Select(x => x.Entity.DomainEvents)
                    .SelectMany(x => x)
                    .Where(domainEvent => !domainEvent.IsPublished)
                    .ToArray();
var result = await base.SaveChangesAsync(cancellationToken);
await DispatchEvents(events);
```

**note:**
From ".ToArray();" Used to assign a new instance of changes to memory so that it is not traceable until "SaveChange" is called. If this method is not used, "ChangeTracker" will still delete the changes from the "events" variable.
 

