### PR TITLE
🏗️ control .net version through global.json

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -12,8 +12,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.100
     - name: Install dotnet ef
       run: dotnet tool install --global dotnet-ef
     - name: Build with dotnet
@@ -33,8 +31,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.100
     - name: run tests
       run: dotnet test CleanArchitecture.sln --configuration Release
       env:

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.100",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
Control the .net version using the global.json file - that way the github action runners will always grab the right version