### PR TITLE
fix(Dockerfile): update to NET 6.0

### DIFF
--- a/src/WebUI/Dockerfile
+++ b/src/WebUI/Dockerfile
@@ -1,13 +1,13 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 # This stage is used for VS debugging on Docker
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 ENV ASPNETCORE_URLS=https://+:5001;http://+:5000
 WORKDIR /app
 EXPOSE 5000
 EXPOSE 5001
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt install -y nodejs
 WORKDIR /src


### PR DESCRIPTION
The .NET projects were migrated to .NET 6.0 but the Dockerfile remained in the 5.0 version