### PR TITLE
Pagination: Added base Query and QueryHandler for simplicity

### DIFF
--- a/src/Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/Application/Common/Interfaces/IApplicationDbContext.cs
@@ -10,4 +10,6 @@ public interface IApplicationDbContext
     DbSet<TodoItem> TodoItems { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);
+
+    DbSet<TEntity> Set<TEntity>() where TEntity : class;
 }

--- a/src/Application/Common/Queries/PageEntityBaseQuery.cs
+++ b/src/Application/Common/Queries/PageEntityBaseQuery.cs
@@ -1,0 +1,46 @@
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
+using CleanArchitecture.Application.Common.Interfaces;
+using CleanArchitecture.Application.Common.Mappings;
+using CleanArchitecture.Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace CleanArchitecture.Application.Common.Queries
+{
+    public class PageEntityBaseQuery<TEntityDto> : IRequest<PaginatedList<TEntityDto>>
+    {
+        public int PageNumber { get; set; } = 1;
+
+        public int PageSize { get; set; } = 10;
+    }
+
+    public abstract class PageEntityBaseQueryHandler<Request, TEntity, TEntityDto> : IRequestHandler<Request, PaginatedList<TEntityDto>>
+    where Request : PageEntityBaseQuery<TEntityDto>
+    where TEntity : class
+    {
+        protected readonly IApplicationDbContext Context;
+
+        protected readonly IMapper Mapper;
+
+        protected DbSet<TEntity> Entity => Context.Set<TEntity>();
+
+        protected abstract IQueryable<TEntity> Query(Request request);
+
+        public PageEntityBaseQueryHandler(
+            IApplicationDbContext context,
+            IMapper mapper)
+        {
+            Context = context;
+            Mapper = mapper;
+        }
+
+        public async Task<PaginatedList<TEntityDto>> Handle(Request request, CancellationToken cancellationToken)
+        {
+
+            return await Query(request)
+            .ProjectTo<TEntityDto>(Mapper.ConfigurationProvider)
+            .PaginatedListAsync(request.PageNumber, request.PageSize);
+        }
+    }
+}

--- a/src/Application/TodoItems/Queries/GetTodoItemsWithPagination/GetTodoItemsWithPaginationQuery.cs
+++ b/src/Application/TodoItems/Queries/GetTodoItemsWithPagination/GetTodoItemsWithPaginationQuery.cs
@@ -1,36 +1,26 @@
 ﻿using AutoMapper;
-using AutoMapper.QueryableExtensions;
 using CleanArchitecture.Application.Common.Interfaces;
-using CleanArchitecture.Application.Common.Mappings;
-using CleanArchitecture.Application.Common.Models;
-using MediatR;
+using CleanArchitecture.Application.Common.Queries;
+using CleanArchitecture.Domain.Entities;
 
 namespace CleanArchitecture.Application.TodoItems.Queries.GetTodoItemsWithPagination;
 
-public class GetTodoItemsWithPaginationQuery : IRequest<PaginatedList<TodoItemBriefDto>>
+public class GetTodoItemsWithPaginationQuery : PageEntityBaseQuery<TodoItemBriefDto>
 {
     public int ListId { get; set; }
-    public int PageNumber { get; set; } = 1;
-    public int PageSize { get; set; } = 10;
+
 }
 
-public class GetTodoItemsWithPaginationQueryHandler : IRequestHandler<GetTodoItemsWithPaginationQuery, PaginatedList<TodoItemBriefDto>>
+public class GetTodoItemsWithPaginationQueryHandler : PageEntityBaseQueryHandler<GetTodoItemsWithPaginationQuery, TodoItem, TodoItemBriefDto>
 {
-    private readonly IApplicationDbContext _context;
-    private readonly IMapper _mapper;
 
-    public GetTodoItemsWithPaginationQueryHandler(IApplicationDbContext context, IMapper mapper)
+    public GetTodoItemsWithPaginationQueryHandler(IApplicationDbContext context, IMapper mapper) : base(context, mapper)
     {
-        _context = context;
-        _mapper = mapper;
     }
 
-    public async Task<PaginatedList<TodoItemBriefDto>> Handle(GetTodoItemsWithPaginationQuery request, CancellationToken cancellationToken)
+    protected override IQueryable<TodoItem> Query(GetTodoItemsWithPaginationQuery request)
     {
-        return await _context.TodoItems
-            .Where(x => x.ListId == request.ListId)
-            .OrderBy(x => x.Title)
-            .ProjectTo<TodoItemBriefDto>(_mapper.ConfigurationProvider)
-            .PaginatedListAsync(request.PageNumber, request.PageSize);
+        return Entity.Where(x => x.ListId == request.ListId)
+        .OrderBy(x => x.Title);
     }
 }


### PR DESCRIPTION
The recent project that I've been working on has a lot of entities to be paginated. I noticed that I've been copy-pasting a lot of common elements for the pagination from one entity to another and the only difference was the entity, filters, dto mapping, and ordering so I thought abstracting these would help improve productivity.