### PR TITLE
Added .AsNoTracking() for list projections

### DIFF
--- a/src/Application/Common/Mappings/MappingExtensions.cs
+++ b/src/Application/Common/Mappings/MappingExtensions.cs
@@ -7,9 +7,9 @@ namespace CleanArchitecture.Application.Common.Mappings;
 
 public static class MappingExtensions
 {
-    public static Task<PaginatedList<TDestination>> PaginatedListAsync<TDestination>(this IQueryable<TDestination> queryable, int pageNumber, int pageSize)
-        => PaginatedList<TDestination>.CreateAsync(queryable, pageNumber, pageSize);
+    public static Task<PaginatedList<TDestination>> PaginatedListAsync<TDestination>(this IQueryable<TDestination> queryable, int pageNumber, int pageSize) where TDestination : class
+        => PaginatedList<TDestination>.CreateAsync(queryable.AsNoTracking(), pageNumber, pageSize);
 
-    public static Task<List<TDestination>> ProjectToListAsync<TDestination>(this IQueryable queryable, IConfigurationProvider configuration)
-        => queryable.ProjectTo<TDestination>(configuration).ToListAsync();
+    public static Task<List<TDestination>> ProjectToListAsync<TDestination>(this IQueryable queryable, IConfigurationProvider configuration) where TDestination : class
+        => queryable.ProjectTo<TDestination>(configuration).AsNoTracking().ToListAsync();
 }


### PR DESCRIPTION
As it is used CQRS pattern for the better performance in read model we could use no-tracking query by default in PaginatedListAsync and ProjectToListAsync methods in mapping extensions.