### PR TITLE
DomainEvents created as a result of an EventHandler should also be published

### DIFF
--- a/src/Infrastructure/Common/MediatorExtensions.cs
+++ b/src/Infrastructure/Common/MediatorExtensions.cs
@@ -10,13 +10,14 @@ public static class MediatorExtensions
         var entities = context.ChangeTracker
             .Entries<BaseEntity>()
             .Where(e => e.Entity.DomainEvents.Any())
-            .Select(e => e.Entity);
+            .Select(e => e.Entity)
+            .ToList();
 
         var domainEvents = entities
             .SelectMany(e => e.DomainEvents)
             .ToList();
 
-        entities.ToList().ForEach(e => e.ClearDomainEvents());
+        entities.ForEach(e => e.ClearDomainEvents());
 
         foreach (var domainEvent in domainEvents)
             await mediator.Publish(domainEvent);

--- a/src/Infrastructure/Common/MediatorExtensions.cs
+++ b/src/Infrastructure/Common/MediatorExtensions.cs
@@ -5,21 +5,29 @@ namespace MediatR;
 
 public static class MediatorExtensions
 {
-    public static async Task DispatchDomainEvents(this IMediator mediator, DbContext context) 
+    public static async Task DispatchDomainEvents(this IMediator mediator, DbContext context)
     {
-        var entities = context.ChangeTracker
+        var entities = GetEntitiesWithPendingEvents(context);
+
+        while (entities.Any())
+        {
+            foreach (var entity in entities)
+            foreach (var domainEvent in entity.DomainEvents.ToList())
+            {
+                await mediator.Publish(domainEvent);
+                entity.RemoveDomainEvent(domainEvent);
+            }
+
+            entities = GetEntitiesWithPendingEvents(context);
+        }
+    }
+
+    private static List<BaseEntity> GetEntitiesWithPendingEvents(DbContext context)
+    {
+        return context.ChangeTracker
             .Entries<BaseEntity>()
             .Where(e => e.Entity.DomainEvents.Any())
             .Select(e => e.Entity)
             .ToList();
-
-        var domainEvents = entities
-            .SelectMany(e => e.DomainEvents)
-            .ToList();
-
-        entities.ForEach(e => e.ClearDomainEvents());
-
-        foreach (var domainEvent in domainEvents)
-            await mediator.Publish(domainEvent);
     }
 }


### PR DESCRIPTION
I think it should be possible for additional DomainEvents to occur while processing DomainEvents. Currently there is only one iteration over the list of events, so additional DomainEvents that occur are not published.
This PR is trying to change that behavior.