### PR TITLE
Using new extension method for struct values

### DIFF
--- a/src/Application/Common/Validations/ValidationsExtensions.cs
+++ b/src/Application/Common/Validations/ValidationsExtensions.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace CleanArchitecture.Application.Common.Validations;
+
+public static class ValidationsExtensions
+{
+    // When case for nullable structs
+    public static IRuleBuilderOptions<T, TProperty?> RangeWithWhen<T, TProperty>(this IRuleBuilder<T, TProperty?> ruleBuilder, string entity, TProperty min, TProperty max, Func<T, bool> expression) where TProperty : struct, IComparable<TProperty>, IComparable => ruleBuilder.InclusiveBetween(min,max).WithMessage($"{entity} should be in range {min} - {max}").When(expression);
+
+    // When case for non nullable structs 
+    public static IRuleBuilderOptions<T, TProperty> RangeWithWhen<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, string entity, TProperty min, TProperty max, Func<T, bool> expression) where TProperty : IComparable<TProperty>, IComparable => ruleBuilder.InclusiveBetween(min,max).WithMessage($"{entity} should be in range {min} - {max}").When(expression);
+}


### PR DESCRIPTION
Idea is instead of all time using chain repeated helper functions from FluentValidation using new extension methods, and advantage is does not matter int, decimal, float or double we can use for all of them, and it is also nullable version.