### PR TITLE
Make Dtos immutable

### DIFF
--- a/src/Application/Common/Models/LookupDto.cs
+++ b/src/Application/Common/Models/LookupDto.cs
@@ -6,7 +6,7 @@ namespace CleanArchitecture.Application.Common.Models;
 // Note: This is currently just used to demonstrate applying multiple IMapFrom attributes.
 public class LookupDto : IMapFrom<TodoList>, IMapFrom<TodoItem>
 {
-    public int Id { get; set; }
+    public int Id { get; init; }
 
-    public string? Title { get; set; }
+    public string? Title { get; init; }
 }

--- a/src/Application/Common/Models/PaginatedList.cs
+++ b/src/Application/Common/Models/PaginatedList.cs
@@ -4,12 +4,12 @@ namespace CleanArchitecture.Application.Common.Models;
 
 public class PaginatedList<T>
 {
-    public List<T> Items { get; }
+    public IReadOnlyCollection<T> Items { get; }
     public int PageNumber { get; }
     public int TotalPages { get; }
     public int TotalCount { get; }
 
-    public PaginatedList(List<T> items, int count, int pageNumber, int pageSize)
+    public PaginatedList(IReadOnlyCollection<T> items, int count, int pageNumber, int pageSize)
     {
         PageNumber = pageNumber;
         TotalPages = (int)Math.Ceiling(count / (double)pageSize);

--- a/src/Application/Common/Models/Result.cs
+++ b/src/Application/Common/Models/Result.cs
@@ -8,9 +8,9 @@ public class Result
         Errors = errors.ToArray();
     }
 
-    public bool Succeeded { get; set; }
+    public bool Succeeded { get; init; }
 
-    public string[] Errors { get; set; }
+    public string[] Errors { get; init; }
 
     public static Result Success()
     {

--- a/src/Application/TodoItems/Queries/GetTodoItemsWithPagination/TodoItemBriefDto.cs
+++ b/src/Application/TodoItems/Queries/GetTodoItemsWithPagination/TodoItemBriefDto.cs
@@ -5,11 +5,11 @@ namespace CleanArchitecture.Application.TodoItems.Queries.GetTodoItemsWithPagina
 
 public class TodoItemBriefDto : IMapFrom<TodoItem>
 {
-    public int Id { get; set; }
+    public int Id { get; init; }
 
-    public int ListId { get; set; }
+    public int ListId { get; init; }
 
-    public string? Title { get; set; }
+    public string? Title { get; init; }
 
-    public bool Done { get; set; }
+    public bool Done { get; init; }
 }

--- a/src/Application/TodoLists/Queries/ExportTodos/ExportTodosVm.cs
+++ b/src/Application/TodoLists/Queries/ExportTodos/ExportTodosVm.cs
@@ -9,9 +9,9 @@ public class ExportTodosVm
         Content = content;
     }
 
-    public string FileName { get; set; }
+    public string FileName { get; init; }
 
-    public string ContentType { get; set; }
+    public string ContentType { get; init; }
 
-    public byte[] Content { get; set; }
+    public byte[] Content { get; init;}
 }

--- a/src/Application/TodoLists/Queries/ExportTodos/TodoItemFileRecord.cs
+++ b/src/Application/TodoLists/Queries/ExportTodos/TodoItemFileRecord.cs
@@ -5,7 +5,7 @@ namespace CleanArchitecture.Application.TodoLists.Queries.ExportTodos;
 
 public class TodoItemRecord : IMapFrom<TodoItem>
 {
-    public string? Title { get; set; }
+    public string? Title { get; init; }
 
-    public bool Done { get; set; }
+    public bool Done { get; init; }
 }

--- a/src/Application/TodoLists/Queries/GetTodos/PriorityLevelDto.cs
+++ b/src/Application/TodoLists/Queries/GetTodos/PriorityLevelDto.cs
@@ -2,7 +2,7 @@
 
 public class PriorityLevelDto
 {
-    public int Value { get; set; }
+    public int Value { get; init; }
 
-    public string? Name { get; set; }
+    public string? Name { get; init; }
 }

--- a/src/Application/TodoLists/Queries/GetTodos/TodoItemDto.cs
+++ b/src/Application/TodoLists/Queries/GetTodos/TodoItemDto.cs
@@ -6,17 +6,17 @@ namespace CleanArchitecture.Application.TodoLists.Queries.GetTodos;
 
 public class TodoItemDto : IMapFrom<TodoItem>
 {
-    public int Id { get; set; }
+    public int Id { get; init; }
 
-    public int ListId { get; set; }
+    public int ListId { get; init; }
 
-    public string? Title { get; set; }
+    public string? Title { get; init; }
 
-    public bool Done { get; set; }
+    public bool Done { get; init; }
 
-    public int Priority { get; set; }
+    public int Priority { get; init; }
 
-    public string? Note { get; set; }
+    public string? Note { get; init; }
 
     public void Mapping(Profile profile)
     {

--- a/src/Application/TodoLists/Queries/GetTodos/TodoListDto.cs
+++ b/src/Application/TodoLists/Queries/GetTodos/TodoListDto.cs
@@ -7,14 +7,14 @@ public class TodoListDto : IMapFrom<TodoList>
 {
     public TodoListDto()
     {
-        Items = new List<TodoItemDto>();
+        Items = Array.Empty<TodoItemDto>();
     }
 
-    public int Id { get; set; }
+    public int Id { get; init; }
 
-    public string? Title { get; set; }
+    public string? Title { get; init; }
 
-    public string? Colour { get; set; }
+    public string? Colour { get; init; }
 
-    public IList<TodoItemDto> Items { get; set; }
+    public IReadOnlyCollection<TodoItemDto> Items { get; init; }
 }

--- a/src/Application/TodoLists/Queries/GetTodos/TodosVm.cs
+++ b/src/Application/TodoLists/Queries/GetTodos/TodosVm.cs
@@ -2,7 +2,7 @@
 
 public class TodosVm
 {
-    public IList<PriorityLevelDto> PriorityLevels { get; set; } = new List<PriorityLevelDto>();
+    public IReadOnlyCollection<PriorityLevelDto> PriorityLevels { get; init; } = Array.Empty<PriorityLevelDto>();
 
-    public IList<TodoListDto> Lists { get; set; } = new List<TodoListDto>();
+    public IReadOnlyCollection<TodoListDto> Lists { get; init; } = Array.Empty<TodoListDto>();
 }

--- a/src/Application/WeatherForecasts/Queries/GetWeatherForecasts/WeatherForecast.cs
+++ b/src/Application/WeatherForecasts/Queries/GetWeatherForecasts/WeatherForecast.cs
@@ -2,11 +2,11 @@
 
 public class WeatherForecast
 {
-    public DateTime Date { get; set; }
+    public DateTime Date { get; init; }
 
-    public int TemperatureC { get; set; }
+    public int TemperatureC { get; init; }
 
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 
-    public string? Summary { get; set; }
+    public string? Summary { get; init; }
 }


### PR DESCRIPTION
# The Problem

Immutable objects are safe to use.

Example:
```
void Foo(Dto dto)
{
   var res1 = service1.Bar(dto);
   var res2 = service2.Bar(dto);
   ...
   Some logic with res1
   ...
   Some logic with res2
   ...
}
```
If dto is immutable, one can safely remove or change the call to `service1` and be sure, that logic related to `res2` is not affected. But if dto is muttable, we have to investigate all possible call chains on service1 in order to make the refactoring, because I don't know in advance how dto is mutated during the call to `service1`.

The good practice is not to mutate objects which are passed as arguments to public methods. This makes maintenance much easier.

Currently, Dtos (under `src/Application`) are not immutable because they contain public setters fields of mutable types like IList

# I'd like

Let's replace set with init Dtos.
Let's replace `IList` with `IReadOnlyCollection` all Dtos.

# Alternatives you've considered

No alternatives :)

We can use arguably `IReadonlyList` instead of `IReadOnlyCollection`, but I would prefer the former because it is more minimalistic.
