### PR TITLE
UnhandledExceptionBehavior Gets Executed Even for Handled Exceptions

### DIFF
--- a/src/Application/ConfigureServices.cs
+++ b/src/Application/ConfigureServices.cs
@@ -12,7 +12,6 @@ public static class ConfigureServices
         services.AddAutoMapper(Assembly.GetExecutingAssembly());
         services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
         services.AddMediatR(Assembly.GetExecutingAssembly());
-        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(UnhandledExceptionBehaviour<,>));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(AuthorizationBehaviour<,>));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehaviour<,>));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(PerformanceBehaviour<,>));

--- a/src/Application/TodoItems/Commands/DeleteTodoItem/DeleteTodoItemCommandExceptionHandlers.cs
+++ b/src/Application/TodoItems/Commands/DeleteTodoItem/DeleteTodoItemCommandExceptionHandlers.cs
@@ -1,0 +1,32 @@
+﻿using CleanArchitecture.Application.Common.Exceptions;
+using MediatR;
+using MediatR.Pipeline;
+using Microsoft.Extensions.Logging;
+
+namespace CleanArchitecture.Application.TodoItems.Commands.DeleteTodoItem;
+
+public class DeleteTodoItemNotFoundExceptionHandler : IRequestExceptionHandler<DeleteTodoItemCommand, Unit, NotFoundException>
+{
+    private readonly ILogger _logger;
+    
+    public DeleteTodoItemNotFoundExceptionHandler(ILogger<DeleteTodoItemNotFoundExceptionHandler> logger)
+    {
+        _logger = logger;
+    }
+    
+    public Task Handle(DeleteTodoItemCommand request,
+        NotFoundException exception,
+        RequestExceptionHandlerState<Unit> state,
+        CancellationToken cancellationToken)
+    {
+        var requestName = request.GetType().Name;
+        
+        _logger.LogWarning(exception,
+            "CleanArchitecture Request: Handled Exception for Request {Name} {@Request}",
+            requestName, request);
+        
+        state.SetHandled(default);
+        
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Application.IntegrationTests/TodoItems/Commands/DeleteTodoItemTests.cs
+++ b/tests/Application.IntegrationTests/TodoItems/Commands/DeleteTodoItemTests.cs
@@ -18,7 +18,7 @@ public class DeleteTodoItemTests : BaseTestFixture
         var command = new DeleteTodoItemCommand(99);
 
         await FluentActions.Invoking(() =>
-            SendAsync(command)).Should().ThrowAsync<NotFoundException>();
+            SendAsync(command)).Should().NotThrowAsync<NotFoundException>();
     }
 
     [Test]


### PR DESCRIPTION
This PR aims to fix the issue #700

I'm not 100% sure to call this a bug, but MediatR allows to use [Exception Handling](https://github.com/jbogard/MediatR/wiki#exceptions-handling). The problem is that by having the UnhandledExceptionBehavior as an IPipelineBehavior it becomes impossible (or at least very hard and overcomplicated) to have handled exceptions because the code under UnhandledExceptionBehavior will execute always and before the code for a handled exception.