### PR TITLE
Fixed warnings caused by IdentityRole.Name being nullable

### DIFF
--- a/src/Application/Common/Behaviours/LoggingBehaviour.cs
+++ b/src/Application/Common/Behaviours/LoggingBehaviour.cs
@@ -21,7 +21,7 @@ public class LoggingBehaviour<TRequest> : IRequestPreProcessor<TRequest> where T
     {
         var requestName = typeof(TRequest).Name;
         var userId = _currentUserService.UserId ?? string.Empty;
-        string userName = string.Empty;
+        string? userName = string.Empty;
 
         if (!string.IsNullOrEmpty(userId))
         {

--- a/src/Application/Common/Interfaces/IIdentityService.cs
+++ b/src/Application/Common/Interfaces/IIdentityService.cs
@@ -4,7 +4,7 @@ namespace CleanArchitecture.Application.Common.Interfaces;
 
 public interface IIdentityService
 {
-    Task<string> GetUserNameAsync(string userId);
+    Task<string?> GetUserNameAsync(string userId);
 
     Task<bool> IsInRoleAsync(string userId, string role);
 

--- a/src/Infrastructure/Identity/IdentityService.cs
+++ b/src/Infrastructure/Identity/IdentityService.cs
@@ -22,7 +22,7 @@ public class IdentityService : IIdentityService
         _authorizationService = authorizationService;
     }
 
-    public async Task<string> GetUserNameAsync(string userId)
+    public async Task<string?> GetUserNameAsync(string userId)
     {
         var user = await _userManager.Users.FirstAsync(u => u.Id == userId);
 

--- a/src/Infrastructure/Persistence/ApplicationDbContextInitialiser.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContextInitialiser.cs
@@ -66,7 +66,10 @@ public class ApplicationDbContextInitialiser
         if (_userManager.Users.All(u => u.UserName != administrator.UserName))
         {
             await _userManager.CreateAsync(administrator, "Administrator1!");
-            await _userManager.AddToRolesAsync(administrator, new [] { administratorRole.Name });
+            if (!string.IsNullOrWhiteSpace(administratorRole.Name))
+            {
+                await _userManager.AddToRolesAsync(administrator, new [] { administratorRole.Name });
+            }
         }
 
         // Default data


### PR DESCRIPTION
Simple fix, but ideally would be great if we could enforce somehow that `IdentityRole.Name` is nullable.  Might be able to do this by implementing our own `RoleStore`, but that seems overkill.