### PR TITLE
Upgrade dotnet from rc2 to 7

### DIFF
--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -10,9 +10,9 @@
 
     <ItemGroup>
         <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="10.3.4" />
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0-rc.2.22472.11" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.4.0" />
+        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Application/Common/Behaviours/AuthorizationBehaviour.cs
+++ b/src/Application/Common/Behaviours/AuthorizationBehaviour.cs
@@ -6,7 +6,7 @@ using MediatR;
 
 namespace CleanArchitecture.Application.Common.Behaviours;
 
-public class AuthorizationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
+public class AuthorizationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
 {
     private readonly ICurrentUserService _currentUserService;
     private readonly IIdentityService _identityService;
@@ -19,7 +19,7 @@ public class AuthorizationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRe
         _identityService = identityService;
     }
 
-    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
         var authorizeAttributes = request.GetType().GetCustomAttributes<AuthorizeAttribute>();
 

--- a/src/Application/Common/Behaviours/PerformanceBehaviour.cs
+++ b/src/Application/Common/Behaviours/PerformanceBehaviour.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace CleanArchitecture.Application.Common.Behaviours;
 
-public class PerformanceBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
+public class PerformanceBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
 {
     private readonly Stopwatch _timer;
     private readonly ILogger<TRequest> _logger;
@@ -24,7 +24,7 @@ public class PerformanceBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequ
         _identityService = identityService;
     }
 
-    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
         _timer.Start();
 

--- a/src/Application/Common/Behaviours/UnhandledExceptionBehaviour.cs
+++ b/src/Application/Common/Behaviours/UnhandledExceptionBehaviour.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace CleanArchitecture.Application.Common.Behaviours;
 
-public class UnhandledExceptionBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
+public class UnhandledExceptionBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
 {
     private readonly ILogger<TRequest> _logger;
 
@@ -12,7 +12,7 @@ public class UnhandledExceptionBehaviour<TRequest, TResponse> : IPipelineBehavio
         _logger = logger;
     }
 
-    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/Application/Common/Behaviours/ValidationBehaviour.cs
+++ b/src/Application/Common/Behaviours/ValidationBehaviour.cs
@@ -5,7 +5,7 @@ using ValidationException = CleanArchitecture.Application.Common.Exceptions.Vali
 namespace CleanArchitecture.Application.Common.Behaviours;
 
 public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-     where TRequest : notnull
+     where TRequest : IRequest<TResponse>
 {
     private readonly IEnumerable<IValidator<TRequest>> _validators;
 
@@ -14,7 +14,7 @@ public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TReque
         _validators = validators;
     }
 
-    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
         if (_validators.Any())
         {

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MediatR" Version="9.0.0" />
+      <PackageReference Include="MediatR" Version="11.1.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Infrastructure/Files/CsvFileBuilder.cs
+++ b/src/Infrastructure/Files/CsvFileBuilder.cs
@@ -15,7 +15,7 @@ public class CsvFileBuilder : ICsvFileBuilder
         {
             using var csvWriter = new CsvWriter(streamWriter, CultureInfo.InvariantCulture);
 
-            csvWriter.Configuration.RegisterClassMap<TodoItemRecordMap>();
+            csvWriter.Context.RegisterClassMap<TodoItemRecordMap>();
             csvWriter.WriteRecords(records);
         }
 

--- a/src/Infrastructure/Files/Maps/TodoItemRecordMap.cs
+++ b/src/Infrastructure/Files/Maps/TodoItemRecordMap.cs
@@ -10,6 +10,6 @@ public class TodoItemRecordMap : ClassMap<TodoItemRecord>
     {
         AutoMap(CultureInfo.InvariantCulture);
 
-        Map(m => m.Done).ConvertUsing(c => c.Done ? "Yes" : "No");
+        Map(m => m.Done).Convert(c => c.Value.Done ? "Yes" : "No");
     }
 }

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -9,12 +9,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="CsvHelper" Version="15.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.0-rc.2.22476.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.0-rc.2.22476.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.0-rc.2.22476.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0-rc.2.22472.11" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0-rc.2.22472.11" />
+        <PackageReference Include="CsvHelper" Version="30.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/WebUI/WebUI.csproj
+++ b/src/WebUI/WebUI.csproj
@@ -20,18 +20,21 @@
     </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
-    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0-rc.2.22472.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0-rc.2.22472.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0-rc.2.22472.11" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.10" />
-    <PackageReference Include="NSwag.AspNetCore" Version="13.16.0" />
-    <PackageReference Include="NSwag.MSBuild" Version="13.16.0">
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="7.0.2" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.18.2" />
+    <PackageReference Include="NSwag.MSBuild" Version="13.18.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
+++ b/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
@@ -21,16 +21,16 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0-rc.2.22476.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="nunit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
+        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.7.0" />
-        <PackageReference Include="Moq" Version="4.18.2" />
-        <PackageReference Include="Respawn" Version="4.0.0" />
+        <PackageReference Include="FluentAssertions" Version="6.9.0" />
+        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="Respawn" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -11,14 +11,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="nunit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
+        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.7.0" />
-        <PackageReference Include="Moq" Version="4.18.2" />
+        <PackageReference Include="FluentAssertions" Version="6.9.0" />
+        <PackageReference Include="Moq" Version="4.18.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Domain.UnitTests/Domain.UnitTests.csproj
+++ b/tests/Domain.UnitTests/Domain.UnitTests.csproj
@@ -11,13 +11,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="nunit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
+        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="FluentAssertions" Version="6.9.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Upgrade dotnet from rc2 to 7
Upgrade ef from rc2 to 7
Upgrade other library and fix breaking changes

List of upgradated library
Application.csproj
FluentValidation.DependencyInjectionExtensions from 10.3.4 to 11.4.0
MediatR.Extensions.Microsoft.DependencyInjection from 9.0.0 to 11.0.0
Microsoft.EntityFrameworkCore 7.0.0-rc.2.22472.11  to 7.0.2

Domain.csproj
MediatR from 9.0.0 to 11.1.0

Infrastructure.csproj
CsvHelper from 15.0.10 to 
Microsoft.AspNetCore.ApiAuthorization.IdentityServer from 7.0.0-rc.2.22476.2 to 30.0.1
Microsoft.AspNetCore.Identity.EntityFrameworkCore from 7.0.0-rc.2.22476.2 to 7.0.2
Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore from 7.0.0-rc.2.22476.2 to 7.0.2
Microsoft.EntityFrameworkCore.SqlServer from 7.0.0-rc.2.22472.11 to 7.0.2
Microsoft.EntityFrameworkCore.InMemory from 7.0.0-rc.2.22472.11 to 7.0.2

WebUi.csproj
FluentValidation.AspNetCore from 10.3.4 to 11.2.2
Microsoft.AspNetCore.ApiAuthorization.IdentityServer from 7.0.0-rc.2.22476.2 to 7.0.2
Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore from 7.0.0-rc.2.22476.2 to 7.0.2
Microsoft.AspNetCore.Identity.EntityFrameworkCore from 7.0.0-rc.2.22476.2 to 7.0.2
Microsoft.AspNetCore.Identity.UI from 7.0.0-rc.2.22476.2 to 7.0.2
Microsoft.AspNetCore.SpaProxy from 7.0.0-rc.2.22476.2 to 7.0.2
Microsoft.EntityFrameworkCore.Relational from 7.0.0-rc.2.22476.2 to 7.0.2
Microsoft.EntityFrameworkCore.SqlServer from 7.0.0-rc.2.22476.2  to 7.0.2
Microsoft.EntityFrameworkCore.Tools from 7.0.0-rc.2.22476.2 to 7.0.2
Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore from 6.0.10 to 7.0.2
NSwag.AspNetCore from 13.16.0 to 13.18.2
NSwag.MSBuild from 13.16.0 to 13.18.2

Application.IntegrationTests.csproj
Microsoft.AspNetCore.Mvc.Testing from 7.0.0-rc.2.22476.2 to 7.0.2
Microsoft.NET.Test.Sdk from 17.3.2 to 17.4.1
NUnit3TestAdapter from 4.2.1 to 4.3.1
FluentAssertions from 6.7.0 to 6.9.0
Moq from 4.18.2 to 4.18.4
Respawn from 4.0.0 to 6.0.0

Application.UnitTests.csproj
Microsoft.NET.Test.Sdk from 17.3.2 to 17.4.1
NUnit3TestAdapter from 4.2.1 to 4.3.1
FluentAssertions from 6.7.0 to 6.9.0
Moq from 4.18.2 to 4.18.4


Domain.UnitTests.csproj
Microsoft.NET.Test.Sdk from 17.3.2 to 17.4.1
NUnit3TestAdapter from 4.2.1 to 4.3.1
FluentAssertions from 6.7.0 to 6.9.0