### PR TITLE
Change the ICurrentUserService to Scoped

### DIFF
--- a/src/WebUI/ConfigureServices.cs
+++ b/src/WebUI/ConfigureServices.cs
@@ -15,7 +15,7 @@ public static class ConfigureServices
     {
         services.AddDatabaseDeveloperPageExceptionFilter();
 
-        services.AddSingleton<ICurrentUserService, CurrentUserService>();
+        services.AddScoped<ICurrentUserService, CurrentUserService>();
 
         services.AddHttpContextAccessor();
 


### PR DESCRIPTION
ICurrentUser was changed to Singleton by PR #168  

But the current user service shouldn't share a single instance in the whole application. With the current behavior being singleton, the UserId is not always guaranteed  to be the one of the current user. 

As an example, inject ICurrentUser in a method that has heavy computation. You get the UserId at the start of the method and start the execution of the heavy task. In the same time , the web server is accessed by another user and the CurrentUserId is then changed to the second user's ID. 

We go back to the long running task for User 1. By the end of it, we check again the currentUserService UserId. This time the Id is the one of the User 2, so we get inconsistent behavior. 

---
The integration tests at the moment are not accounting for this as in them we set the CurrentUserService in them as Transient 

CustomWebApplicationFactory.cs

`builder.ConfigureServices((builder, services) =>
        {

            services
                .Remove<ICurrentUserService>()
                .AddTransient(provider => Mock.Of<ICurrentUserService>(s =>
                    s.UserId == GetCurrentUserId()));
        });`
        
        
Also the linked David Fowler article in #168 doesn't mention anywhere that we should use a Singleton for this case. 

https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AspNetCoreGuidance.md#do-not-store-ihttpcontextaccessorhttpcontext-in-a-field