### PR TITLE
Library Upgrade and Mediatr 12 fix

### DIFF
--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -10,9 +10,8 @@
 
     <ItemGroup>
         <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.4.0" />
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.2" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Application/Common/Behaviours/AuthorizationBehaviour.cs
+++ b/src/Application/Common/Behaviours/AuthorizationBehaviour.cs
@@ -6,7 +6,7 @@ using MediatR;
 
 namespace CleanArchitecture.Application.Common.Behaviours;
 
-public class AuthorizationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
+public class AuthorizationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
 {
     private readonly ICurrentUserService _currentUserService;
     private readonly IIdentityService _identityService;

--- a/src/Application/Common/Behaviours/PerformanceBehaviour.cs
+++ b/src/Application/Common/Behaviours/PerformanceBehaviour.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace CleanArchitecture.Application.Common.Behaviours;
 
-public class PerformanceBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
+public class PerformanceBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
 {
     private readonly Stopwatch _timer;
     private readonly ILogger<TRequest> _logger;

--- a/src/Application/Common/Behaviours/UnhandledExceptionBehaviour.cs
+++ b/src/Application/Common/Behaviours/UnhandledExceptionBehaviour.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace CleanArchitecture.Application.Common.Behaviours;
 
-public class UnhandledExceptionBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
+public class UnhandledExceptionBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
 {
     private readonly ILogger<TRequest> _logger;
 

--- a/src/Application/Common/Behaviours/ValidationBehaviour.cs
+++ b/src/Application/Common/Behaviours/ValidationBehaviour.cs
@@ -5,7 +5,7 @@ using ValidationException = CleanArchitecture.Application.Common.Exceptions.Vali
 namespace CleanArchitecture.Application.Common.Behaviours;
 
 public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-     where TRequest : IRequest<TResponse>
+     where TRequest : notnull
 {
     private readonly IEnumerable<IValidator<TRequest>> _validators;
 

--- a/src/Application/ConfigureServices.cs
+++ b/src/Application/ConfigureServices.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using CleanArchitecture.Application.Common.Behaviours;
+using CleanArchitecture.Application.Common.Exceptions;
 using FluentValidation;
 using MediatR;
 
@@ -11,11 +12,14 @@ public static class ConfigureServices
     {
         services.AddAutoMapper(Assembly.GetExecutingAssembly());
         services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
-        services.AddMediatR(Assembly.GetExecutingAssembly());
-        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(UnhandledExceptionBehaviour<,>));
-        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(AuthorizationBehaviour<,>));
-        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehaviour<,>));
-        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(PerformanceBehaviour<,>));
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly());
+            cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(UnhandledExceptionBehaviour<,>));
+            cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(AuthorizationBehaviour<,>));
+            cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(ValidationBehaviour<,>));
+            cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(PerformanceBehaviour<,>));
+
+        });
 
         return services;
     }

--- a/src/Application/TodoItems/Commands/DeleteTodoItem/DeleteTodoItemCommand.cs
+++ b/src/Application/TodoItems/Commands/DeleteTodoItem/DeleteTodoItemCommand.cs
@@ -17,7 +17,7 @@ public class DeleteTodoItemCommandHandler : IRequestHandler<DeleteTodoItemComman
         _context = context;
     }
 
-    public async Task<Unit> Handle(DeleteTodoItemCommand request, CancellationToken cancellationToken)
+    public async Task Handle(DeleteTodoItemCommand request, CancellationToken cancellationToken)
     {
         var entity = await _context.TodoItems
             .FindAsync(new object[] { request.Id }, cancellationToken);
@@ -32,7 +32,6 @@ public class DeleteTodoItemCommandHandler : IRequestHandler<DeleteTodoItemComman
         entity.AddDomainEvent(new TodoItemDeletedEvent(entity));
 
         await _context.SaveChangesAsync(cancellationToken);
-
-        return Unit.Value;
     }
+
 }

--- a/src/Application/TodoItems/Commands/UpdateTodoItem/UpdateTodoItemCommand.cs
+++ b/src/Application/TodoItems/Commands/UpdateTodoItem/UpdateTodoItemCommand.cs
@@ -23,7 +23,7 @@ public class UpdateTodoItemCommandHandler : IRequestHandler<UpdateTodoItemComman
         _context = context;
     }
 
-    public async Task<Unit> Handle(UpdateTodoItemCommand request, CancellationToken cancellationToken)
+    public async Task Handle(UpdateTodoItemCommand request, CancellationToken cancellationToken)
     {
         var entity = await _context.TodoItems
             .FindAsync(new object[] { request.Id }, cancellationToken);
@@ -37,7 +37,5 @@ public class UpdateTodoItemCommandHandler : IRequestHandler<UpdateTodoItemComman
         entity.Done = request.Done;
 
         await _context.SaveChangesAsync(cancellationToken);
-
-        return Unit.Value;
     }
 }

--- a/src/Application/TodoItems/Commands/UpdateTodoItemDetail/UpdateTodoItemDetailCommand.cs
+++ b/src/Application/TodoItems/Commands/UpdateTodoItemDetail/UpdateTodoItemDetailCommand.cs
@@ -26,7 +26,7 @@ public class UpdateTodoItemDetailCommandHandler : IRequestHandler<UpdateTodoItem
         _context = context;
     }
 
-    public async Task<Unit> Handle(UpdateTodoItemDetailCommand request, CancellationToken cancellationToken)
+    public async Task Handle(UpdateTodoItemDetailCommand request, CancellationToken cancellationToken)
     {
         var entity = await _context.TodoItems
             .FindAsync(new object[] { request.Id }, cancellationToken);
@@ -41,7 +41,5 @@ public class UpdateTodoItemDetailCommandHandler : IRequestHandler<UpdateTodoItem
         entity.Note = request.Note;
 
         await _context.SaveChangesAsync(cancellationToken);
-
-        return Unit.Value;
     }
 }

--- a/src/Application/TodoLists/Commands/DeleteTodoList/DeleteTodoListCommand.cs
+++ b/src/Application/TodoLists/Commands/DeleteTodoList/DeleteTodoListCommand.cs
@@ -17,7 +17,7 @@ public class DeleteTodoListCommandHandler : IRequestHandler<DeleteTodoListComman
         _context = context;
     }
 
-    public async Task<Unit> Handle(DeleteTodoListCommand request, CancellationToken cancellationToken)
+    public async Task Handle(DeleteTodoListCommand request, CancellationToken cancellationToken)
     {
         var entity = await _context.TodoLists
             .Where(l => l.Id == request.Id)
@@ -31,7 +31,5 @@ public class DeleteTodoListCommandHandler : IRequestHandler<DeleteTodoListComman
         _context.TodoLists.Remove(entity);
 
         await _context.SaveChangesAsync(cancellationToken);
-
-        return Unit.Value;
     }
 }

--- a/src/Application/TodoLists/Commands/PurgeTodoLists/PurgeTodoListsCommand.cs
+++ b/src/Application/TodoLists/Commands/PurgeTodoLists/PurgeTodoListsCommand.cs
@@ -17,12 +17,10 @@ public class PurgeTodoListsCommandHandler : IRequestHandler<PurgeTodoListsComman
         _context = context;
     }
 
-    public async Task<Unit> Handle(PurgeTodoListsCommand request, CancellationToken cancellationToken)
+    public async Task Handle(PurgeTodoListsCommand request, CancellationToken cancellationToken)
     {
         _context.TodoLists.RemoveRange(_context.TodoLists);
 
         await _context.SaveChangesAsync(cancellationToken);
-
-        return Unit.Value;
     }
 }

--- a/src/Application/TodoLists/Commands/UpdateTodoList/UpdateTodoListCommand.cs
+++ b/src/Application/TodoLists/Commands/UpdateTodoList/UpdateTodoListCommand.cs
@@ -21,7 +21,7 @@ public class UpdateTodoListCommandHandler : IRequestHandler<UpdateTodoListComman
         _context = context;
     }
 
-    public async Task<Unit> Handle(UpdateTodoListCommand request, CancellationToken cancellationToken)
+    public async Task Handle(UpdateTodoListCommand request, CancellationToken cancellationToken)
     {
         var entity = await _context.TodoLists
             .FindAsync(new object[] { request.Id }, cancellationToken);
@@ -35,6 +35,5 @@ public class UpdateTodoListCommandHandler : IRequestHandler<UpdateTodoListComman
 
         await _context.SaveChangesAsync(cancellationToken);
 
-        return Unit.Value;
     }
 }

--- a/src/Application/WeatherForecasts/Queries/GetWeatherForecasts/GetWeatherForecastsQuery.cs
+++ b/src/Application/WeatherForecasts/Queries/GetWeatherForecasts/GetWeatherForecastsQuery.cs
@@ -4,14 +4,14 @@ namespace CleanArchitecture.Application.WeatherForecasts.Queries.GetWeatherForec
 
 public record GetWeatherForecastsQuery : IRequest<IEnumerable<WeatherForecast>>;
 
-public class GetWeatherForecastsQueryHandler : RequestHandler<GetWeatherForecastsQuery, IEnumerable<WeatherForecast>>
+public class GetWeatherForecastsQueryHandler : IRequestHandler<GetWeatherForecastsQuery, IEnumerable<WeatherForecast>>
 {
     private static readonly string[] Summaries = new[]
     {
         "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
     };
 
-    protected override IEnumerable<WeatherForecast> Handle(GetWeatherForecastsQuery request)
+    public async Task<IEnumerable<WeatherForecast>> Handle(GetWeatherForecastsQuery request, CancellationToken cancellationToken)
     {
         var rng = new Random();
 

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MediatR" Version="11.1.0" />
+      <PackageReference Include="MediatR" Version="12.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -10,11 +10,11 @@
 
     <ItemGroup>
         <PackageReference Include="CsvHelper" Version="30.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/WebUI/WebUI.csproj
+++ b/src/WebUI/WebUI.csproj
@@ -22,18 +22,18 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
-        <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.2">
+        <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="7.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="7.0.3" />
         <PackageReference Include="NSwag.AspNetCore" Version="13.18.2" />
         <PackageReference Include="NSwag.MSBuild" Version="13.18.2">
             <PrivateAssets>all</PrivateAssets>

--- a/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
+++ b/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
@@ -21,14 +21,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="nunit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.9.0" />
+        <PackageReference Include="FluentAssertions" Version="6.10.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="Respawn" Version="6.0.0" />
     </ItemGroup>

--- a/tests/Application.IntegrationTests/Testing.cs
+++ b/tests/Application.IntegrationTests/Testing.cs
@@ -42,6 +42,15 @@ public partial class Testing
         return await mediator.Send(request);
     }
 
+    public static async Task SendAsync(IBaseRequest request)
+    {
+        using var scope = _scopeFactory.CreateScope();
+
+        var mediator = scope.ServiceProvider.GetRequiredService<ISender>();
+
+        await mediator.Send(request);
+    }
+
     public static string? GetCurrentUserId()
     {
         return _currentUserId;

--- a/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -11,13 +11,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="nunit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.9.0" />
+        <PackageReference Include="FluentAssertions" Version="6.10.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
     </ItemGroup>
 

--- a/tests/Domain.UnitTests/Domain.UnitTests.csproj
+++ b/tests/Domain.UnitTests/Domain.UnitTests.csproj
@@ -11,13 +11,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="nunit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.9.0" />
+        <PackageReference Include="FluentAssertions" Version="6.10.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Upgrade .net from 7.0.2 to 7.0.3
Upgrade FluentValidation from 11.0.4 to 11.5.1
Upgrade MediatR from 11.1.0 to 12.0.0
Upgrade EntityFramework from 7.0.2 to 7.0.3
Upgrade FluentAssertions from 6.9.0 to 6.10.0