### PR TITLE
Replace OIDC client js with ts

### DIFF
--- a/src/WebUI/ClientApp/angular.json
+++ b/src/WebUI/ClientApp/angular.json
@@ -23,9 +23,6 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
-            "allowedCommonJsDependencies": [
-              "oidc-client"
-            ],
             "assets": [
               "src/assets"
             ],

--- a/src/WebUI/ClientApp/angular.json
+++ b/src/WebUI/ClientApp/angular.json
@@ -23,6 +23,9 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
+            "allowedCommonJsDependencies": [
+              "crypto-js"
+            ],
             "assets": [
               "src/assets"
             ],

--- a/src/WebUI/ClientApp/package-lock.json
+++ b/src/WebUI/ClientApp/package-lock.json
@@ -21,7 +21,6 @@
         "bootstrap-icons": "^1.8.3",
         "jquery": "^3.6.0",
         "ngx-bootstrap": "9.0.0",
-        "oidc-client": "^1.11.5",
         "popper.js": "^1.16.0",
         "run-script-os": "^1.1.6",
         "rxjs": "~7.5.6",
@@ -3234,17 +3233,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/adjust-sourcemap-loader": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
@@ -3630,6 +3618,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4368,16 +4357,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/core-js": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.24.1.tgz",
-      "integrity": "sha512-0QTBSYSUZ6Gq21utGzkfITDylE8jWC9Ne1D2MrhvlsZBI1x39OdDIVbzSqtgMndIy6BlHxBXpMGqzZmnztg2rg==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-js-compat": {
       "version": "3.24.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.24.1.tgz",
@@ -4548,11 +4527,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/css": {
       "version": "3.0.0",
@@ -8455,26 +8429,6 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
-    "node_modules/oidc-client": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.5.tgz",
-      "integrity": "sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==",
-      "dependencies": {
-        "acorn": "^7.4.1",
-        "base64-js": "^1.5.1",
-        "core-js": "^3.8.3",
-        "crypto-js": "^4.0.0",
-        "serialize-javascript": "^4.0.0"
-      }
-    },
-    "node_modules/oidc-client/node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -9746,6 +9700,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -10171,7 +10126,8 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -14357,11 +14313,6 @@
         "negotiator": "0.6.3"
       }
     },
-    "acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
-    },
     "adjust-sourcemap-loader": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
@@ -14644,7 +14595,8 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
     },
     "base64id": {
       "version": "2.0.0",
@@ -15191,11 +15143,6 @@
         }
       }
     },
-    "core-js": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.24.1.tgz",
-      "integrity": "sha512-0QTBSYSUZ6Gq21utGzkfITDylE8jWC9Ne1D2MrhvlsZBI1x39OdDIVbzSqtgMndIy6BlHxBXpMGqzZmnztg2rg=="
-    },
     "core-js-compat": {
       "version": "3.24.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.24.1.tgz",
@@ -15329,11 +15276,6 @@
           }
         }
       }
-    },
-    "crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "css": {
       "version": "3.0.0",
@@ -18164,28 +18106,6 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
-    "oidc-client": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.5.tgz",
-      "integrity": "sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==",
-      "requires": {
-        "acorn": "^7.4.1",
-        "base64-js": "^1.5.1",
-        "core-js": "^3.8.3",
-        "crypto-js": "^4.0.0",
-        "serialize-javascript": "^4.0.0"
-      },
-      "dependencies": {
-        "serialize-javascript": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-          "requires": {
-            "randombytes": "^2.1.0"
-          }
-        }
-      }
-    },
     "on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -19005,6 +18925,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -19335,7 +19256,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/src/WebUI/ClientApp/package-lock.json
+++ b/src/WebUI/ClientApp/package-lock.json
@@ -21,6 +21,7 @@
         "bootstrap-icons": "^1.8.3",
         "jquery": "^3.6.0",
         "ngx-bootstrap": "9.0.0",
+        "oidc-client-ts": "^2.2.2",
         "popper.js": "^1.16.0",
         "run-script-os": "^1.1.6",
         "rxjs": "~7.5.6",
@@ -4528,6 +4529,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+    },
     "node_modules/css": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
@@ -7088,6 +7094,11 @@
         "node >= 0.2.0"
       ]
     },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
     "node_modules/karma": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.0.tgz",
@@ -8428,6 +8439,18 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
+    },
+    "node_modules/oidc-client-ts": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-2.2.2.tgz",
+      "integrity": "sha512-tEpnC1xQX6PMhnDMNEvDhpqnsu0buh29b/sA9a1I5tq6lD87wRAW1rTj49B2+5925I0sQlvU64DoK0Pxeiu7Dg==",
+      "dependencies": {
+        "crypto-js": "^4.1.1",
+        "jwt-decode": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -15277,6 +15300,11 @@
         }
       }
     },
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+    },
     "css": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
@@ -17101,6 +17129,11 @@
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "dev": true
     },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
     "karma": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.0.tgz",
@@ -18105,6 +18138,15 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
+    },
+    "oidc-client-ts": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-2.2.2.tgz",
+      "integrity": "sha512-tEpnC1xQX6PMhnDMNEvDhpqnsu0buh29b/sA9a1I5tq6lD87wRAW1rTj49B2+5925I0sQlvU64DoK0Pxeiu7Dg==",
+      "requires": {
+        "crypto-js": "^4.1.1",
+        "jwt-decode": "^3.1.2"
+      }
     },
     "on-finished": {
       "version": "2.4.1",

--- a/src/WebUI/ClientApp/package.json
+++ b/src/WebUI/ClientApp/package.json
@@ -27,6 +27,7 @@
     "bootstrap-icons": "^1.8.3",
     "jquery": "^3.6.0",
     "ngx-bootstrap": "9.0.0",
+    "oidc-client-ts": "^2.2.2",
     "popper.js": "^1.16.0",
     "run-script-os": "^1.1.6",
     "rxjs": "~7.5.6",

--- a/src/WebUI/ClientApp/package.json
+++ b/src/WebUI/ClientApp/package.json
@@ -27,7 +27,6 @@
     "bootstrap-icons": "^1.8.3",
     "jquery": "^3.6.0",
     "ngx-bootstrap": "9.0.0",
-    "oidc-client": "^1.11.5",
     "popper.js": "^1.16.0",
     "run-script-os": "^1.1.6",
     "rxjs": "~7.5.6",
@@ -51,6 +50,5 @@
   },
   "overrides": {
     "autoprefixer": "10.4.5"
-  },
-  "optionalDependencies": {}
+  }
 }

--- a/src/WebUI/ClientApp/src/api-authorization/authorize.service.ts
+++ b/src/WebUI/ClientApp/src/api-authorization/authorize.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { User, UserManager } from 'oidc-client';
+import { User, UserManager } from 'oidc-client-ts';
 import { BehaviorSubject, concat, from, Observable } from 'rxjs';
 import { filter, map, mergeMap, take, tap } from 'rxjs/operators';
 import { ApplicationPaths, ApplicationName } from './api-authorization.constants';

--- a/src/WebUI/ClientApp/src/api-authorization/authorize.service.ts
+++ b/src/WebUI/ClientApp/src/api-authorization/authorize.service.ts
@@ -182,6 +182,7 @@ export class AuthorizeService {
     const settings: any = await response.json();
     settings.automaticSilentRenew = true;
     settings.includeIdTokenInSilentRenew = true;
+    settings.loadUserInfo = true;
     this.userManager = new UserManager(settings);
 
     this.userManager.events.addUserSignedOut(async () => {

--- a/src/WebUI/ClientApp/src/api-authorization/authorize.service.ts
+++ b/src/WebUI/ClientApp/src/api-authorization/authorize.service.ts
@@ -144,7 +144,7 @@ export class AuthorizeService {
   public async completeSignOut(url: string): Promise<IAuthenticationResult> {
     await this.ensureUserManagerInitialized();
     try {
-      const response = await this.userManager!.signoutCallback(url);
+      const response = await this.userManager!.signoutRedirectCallback(url);
       this.userSubject.next(null);
       return this.success(response && response.state);
     } catch (error: any) {


### PR DESCRIPTION
Currently used [oidc-client](https://github.com/IdentityModel/oidc-client-js) package is no longer maintained, and another successor project [oidc-client-ts](https://github.com/authts/oidc-client-ts) (forked from original package) is showing great promise. 

This PR more or less just replaces oidc-client with oidc-client-ts with some minor changes; more or less highlighted in the [migration guide](https://github.com/authts/oidc-client-ts/blob/main/docs/migration.md).

- Default of `loadUserInfo` changed from `true` → `false`
- `allowedCommonJsDependencies` within `angular.json`: replaced `oidc-client` (no longer used/older package) with `crypto-js` (one of the dependencies for oidc-client-ts. Just removes [build warnings](https://angular.io/guide/build#configuring-commonjs-dependencies).