### PR TITLE
Update `MappingProfile` to allow for `IMapFrom` implementations without a default constructor

### DIFF
--- a/src/Application/Common/Mappings/MappingProfile.cs
+++ b/src/Application/Common/Mappings/MappingProfile.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.Serialization;
 using AutoMapper;
 
 namespace CleanArchitecture.Application.Common.Mappings;
@@ -24,7 +25,7 @@ public class MappingProfile : Profile
 
         foreach (var type in types)
         {
-            var instance = Activator.CreateInstance(type);
+            var instance = FormatterServices.GetUninitializedObject(type);
             
             var methodInfo = type.GetMethod(mappingMethodName);
 


### PR DESCRIPTION
Per issue #836, I've updated the `MappingProfile` to leverage `FormatterServices.GetUninitializedObject` instead of `Activator.CreateInstance`. This change will allow classes without default constructors to still use the `IMapFrom` interface to automatically configure AutoMapper profiles.