### PR TITLE
💡 Describe the reasoning behind BaseEntity.Id key type.

### DIFF
--- a/src/Domain/Common/BaseEntity.cs
+++ b/src/Domain/Common/BaseEntity.cs
@@ -4,6 +4,8 @@ namespace CleanArchitecture.Domain.Common;
 
 public abstract class BaseEntity
 {
+    // This can easily be modified to be BaseEntity<T> and public T Id to support different key types.
+    // Using non-generic integer types for simplicity
     public int Id { get; set; }
 
     private readonly List<BaseEvent> _domainEvents = new();


### PR DESCRIPTION
Rather than support generic key types as proposed in #826, I have included a comment to describe the reasoning behind BaseEntity.Id key type. This is inline with the approach taken in [eShopOnWeb](https://github.com/dotnet-architecture/eShopOnWeb/blob/main/src/ApplicationCore/Entities/BaseEntity.cs).