### PR TITLE
Fix update entry in AuditableEntity Interceptor

### DIFF
--- a/src/Infrastructure/Persistence/Interceptors/AuditableEntitySaveChangesInterceptor.cs
+++ b/src/Infrastructure/Persistence/Interceptors/AuditableEntitySaveChangesInterceptor.cs
@@ -45,7 +45,7 @@ public class AuditableEntitySaveChangesInterceptor : SaveChangesInterceptor
                 entry.Entity.Created = _dateTime.Now;
             } 
 
-            if (entry.State == EntityState.Added || entry.State == EntityState.Modified || entry.HasChangedOwnedEntities())
+            if (entry.State == EntityState.Modified || entry.HasChangedOwnedEntities())
             {
                 entry.Entity.LastModifiedBy = _user.Id;
                 entry.Entity.LastModified = _dateTime.Now;


### PR DESCRIPTION
The condition "entry.State == EntityState.Added" is repeated while checking the EntityState for Add and Update.

![image](https://github.com/jasontaylordev/CleanArchitecture/assets/405829/db7b8f91-1afe-4788-867c-5c15b315207c)
