### PR TITLE
Replaced DateTimeService with System.TimeProvider

### DIFF
--- a/src/Application/Common/Interfaces/IDateTime.cs
+++ b/src/Application/Common/Interfaces/IDateTime.cs
@@ -1,6 +1,0 @@
-﻿namespace CleanArchitecture.Application.Common.Interfaces;
-
-public interface IDateTime
-{
-    DateTime Now { get; }
-}

--- a/src/Infrastructure/ConfigureServices.cs
+++ b/src/Infrastructure/ConfigureServices.cs
@@ -3,7 +3,6 @@ using CleanArchitecture.Infrastructure.Files;
 using CleanArchitecture.Infrastructure.Identity;
 using CleanArchitecture.Infrastructure.Persistence;
 using CleanArchitecture.Infrastructure.Persistence.Interceptors;
-using CleanArchitecture.Infrastructure.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -36,8 +35,7 @@ public static class ConfigureServices
             .AddDefaultIdentity<ApplicationUser>()
             .AddRoles<IdentityRole>()
             .AddEntityFrameworkStores<ApplicationDbContext>();
-
-        services.AddTransient<IDateTime, DateTimeService>();
+        
         services.AddTransient<IIdentityService, IdentityService>();
         services.AddTransient<ICsvFileBuilder, CsvFileBuilder>();
 

--- a/src/Infrastructure/Persistence/Interceptors/AuditableEntitySaveChangesInterceptor.cs
+++ b/src/Infrastructure/Persistence/Interceptors/AuditableEntitySaveChangesInterceptor.cs
@@ -9,14 +9,14 @@ namespace CleanArchitecture.Infrastructure.Persistence.Interceptors;
 public class AuditableEntitySaveChangesInterceptor : SaveChangesInterceptor
 {
     private readonly IUser _user;
-    private readonly IDateTime _dateTime;
+    private readonly TimeProvider _timeProvider;
 
     public AuditableEntitySaveChangesInterceptor(
         IUser user,
-        IDateTime dateTime)
+        TimeProvider timeProvider)
     {
         _user = user;
-        _dateTime = dateTime;
+        _timeProvider = timeProvider;
     }
 
     public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
@@ -42,13 +42,13 @@ public class AuditableEntitySaveChangesInterceptor : SaveChangesInterceptor
             if (entry.State == EntityState.Added)
             {
                 entry.Entity.CreatedBy = _user.Id;
-                entry.Entity.Created = _dateTime.Now;
+                entry.Entity.Created = _timeProvider.GetLocalNow().DateTime;
             } 
 
             if (entry.State == EntityState.Added || entry.State == EntityState.Modified || entry.HasChangedOwnedEntities())
             {
                 entry.Entity.LastModifiedBy = _user.Id;
-                entry.Entity.LastModified = _dateTime.Now;
+                entry.Entity.LastModified = _timeProvider.GetLocalNow().DateTime;
             }
         }
     }

--- a/src/Infrastructure/Services/DateTimeService.cs
+++ b/src/Infrastructure/Services/DateTimeService.cs
@@ -1,8 +1,0 @@
-﻿using CleanArchitecture.Application.Common.Interfaces;
-
-namespace CleanArchitecture.Infrastructure.Services;
-
-public class DateTimeService : IDateTime
-{
-    public DateTime Now => DateTime.Now;
-}


### PR DESCRIPTION
Starting from .NET 8 there is an inbuild TimeProvider Class which can be used as an abstractrion over DateTime. https://learn.microsoft.com/en-us/dotnet/api/system.timeprovider?view=net-8.0