### PR TITLE
Replace Moq with NSubstitute

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,50 +1,51 @@
 <!-- For more info on central package management go to https://devblogs.microsoft.com/nuget/introducing-central-package-management/ -->
 <Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageVersion Include="Ardalis.GuardClauses" Version="4.0.1" />
-        <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-        <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-        <PackageVersion Include="FluentAssertions" Version="6.11.0" />
-        <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />
-        <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.2" />
-        <PackageVersion Include="MediatR" Version="12.0.1" />
-        <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0-preview.5.23302.2" />
-        <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0-preview.5.23302.2" />
-        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.5.23302.2" />
-        <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0-preview.5.23302.2" />
-        <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.0-preview.5.23302.2" />
-        <!--#if (!UseApiOnly)-->
-        <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.0-preview.5.23302.2" />
-        <!--#endif-->
-        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.0-preview.5.23280.1" />
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0-preview.5.23280.1" />
-        <!--#if (UseSQLite)-->
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-preview.5.23280.1" />
-        <!--#endif-->
-        <!--#if (UseLocalDB)-->
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0-preview.5.23280.1" />
-        <!--#endif-->
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0-preview.5.23280.1" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0-preview.5.23280.8" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0-preview.5.23280.8" />
-        <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.0-preview.5.23302.2" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-        <PackageVersion Include="Moq" Version="4.18.4" />
-        <PackageVersion Include="NSwag.AspNetCore" Version="13.19.0" />
-        <PackageVersion Include="NSwag.MSBuild" Version="13.19.0" />
-        <PackageVersion Include="nunit" Version="3.13.3" />
-        <PackageVersion Include="NUnit.Analyzers" Version="3.6.1" />
-        <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
-        <PackageVersion Include="Respawn" Version="6.0.0" />
-        <PackageVersion Include="Testcontainers.MsSql" Version="3.3.0" />
-        <PackageVersion Include="ZymLabs.NSwag.FluentValidation.AspNetCore" Version="0.6.2" />
-        <!--#if(!UseApiOnly)-->
-        <PackageVersion Include="Microsoft.Playwright" Version="1.35.0" />
-        <PackageVersion Include="SpecFlow.Plus.LivingDocPlugin" Version="3.9.57" />
-        <PackageVersion Include="SpecFlow.NUnit" Version="3.9.74" />
-        <!--#endif-->
-    </ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Ardalis.GuardClauses" Version="4.0.1" />
+    <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.11.0" />
+    <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.2" />
+    <PackageVersion Include="MediatR" Version="12.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0-preview.5.23302.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0-preview.5.23302.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.5.23302.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0-preview.5.23302.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.0-preview.5.23302.2" />
+    <!--#if (!UseApiOnly)-->
+    <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.0-preview.5.23302.2" />
+    <!--#endif-->
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.0-preview.5.23280.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0-preview.5.23280.1" />
+    <!--#if (UseSQLite)-->
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-preview.5.23280.1" />
+    <!--#endif-->
+    <!--#if (UseLocalDB)-->
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0-preview.5.23280.1" />
+    <!--#endif-->
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0-preview.5.23280.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0-preview.5.23280.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0-preview.5.23280.8" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.0-preview.5.23302.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="NSubstitute" Version="5.0.0" />
+    <PackageVersion Include="NSwag.AspNetCore" Version="13.19.0" />
+    <PackageVersion Include="NSwag.MSBuild" Version="13.19.0" />
+    <PackageVersion Include="nunit" Version="3.13.3" />
+    <PackageVersion Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageVersion Include="Respawn" Version="6.0.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="3.3.0" />
+    <PackageVersion Include="ZymLabs.NSwag.FluentValidation.AspNetCore" Version="0.6.2" />
+    <!--#if(!UseApiOnly)-->
+    <PackageVersion Include="Microsoft.Playwright" Version="1.35.0" />
+    <PackageVersion Include="SpecFlow.Plus.LivingDocPlugin" Version="3.9.57" />
+    <PackageVersion Include="SpecFlow.NUnit" Version="3.9.74" />
+    <!--#endif-->
+  </ItemGroup>
 </Project>

--- a/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
+++ b/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
@@ -13,12 +13,12 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
         <PackageReference Include="nunit" />
         <PackageReference Include="NUnit.Analyzers" />
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.collector" />
         <PackageReference Include="FluentAssertions" />
-        <PackageReference Include="Moq" />
         <PackageReference Include="Respawn" />
         <PackageReference Include="Testcontainers.MsSql" />
     </ItemGroup>

--- a/tests/Application.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/tests/Application.IntegrationTests/CustomWebApplicationFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System.Data.Common;
 using CleanArchitecture.Application.Common.Interfaces;
 using CleanArchitecture.Infrastructure.Data;
+using FluentAssertions.Common;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
@@ -26,8 +27,13 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
         builder.ConfigureTestServices(services =>
         {
             services
-                .RemoveAll<IUser>()
-                .AddTransient(provider => Mock.Of<IUser>(s => s.Id == GetUserId()));
+            .RemoveAll<IUser>()
+                .AddTransient(provider =>
+            {
+                var user = Substitute.For<IUser>();
+                user.Id.Returns(GetUserId());
+                return user;
+            });
 
             services
                 .RemoveAll<DbContextOptions<ApplicationDbContext>>()

--- a/tests/Application.IntegrationTests/GlobalUsings.cs
+++ b/tests/Application.IntegrationTests/GlobalUsings.cs
@@ -1,4 +1,4 @@
 ﻿global using Ardalis.GuardClauses;
 global using FluentAssertions;
-global using Moq;
+global using NSubstitute;
 global using NUnit.Framework;

--- a/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -12,12 +12,12 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
         <PackageReference Include="nunit" />
         <PackageReference Include="NUnit.Analyzers" />
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.collector" />
         <PackageReference Include="FluentAssertions" />
-        <PackageReference Include="Moq" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Application.UnitTests/Common/Behaviours/RequestLoggerTests.cs
+++ b/tests/Application.UnitTests/Common/Behaviours/RequestLoggerTests.cs
@@ -2,44 +2,44 @@
 using CleanArchitecture.Application.Common.Interfaces;
 using CleanArchitecture.Application.TodoItems.Commands.CreateTodoItem;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace CleanArchitecture.Application.UnitTests.Common.Behaviours;
 
 public class RequestLoggerTests
 {
-    private Mock<ILogger<CreateTodoItemCommand>> _logger = null!;
-    private Mock<IUser> _user = null!;
-    private Mock<IIdentityService> _identityService = null!;
+    private ILogger<CreateTodoItemCommand> _logger = null!;
+    private IUser _user = null!;
+    private IIdentityService _identityService = null!;
 
     [SetUp]
     public void Setup()
     {
-        _logger = new Mock<ILogger<CreateTodoItemCommand>>();
-        _user = new Mock<IUser>();
-        _identityService = new Mock<IIdentityService>();
+        _logger = Substitute.For<ILogger<CreateTodoItemCommand>>();
+        _user = Substitute.For<IUser>();
+        _identityService = Substitute.For<IIdentityService>();
     }
 
     [Test]
     public async Task ShouldCallGetUserNameAsyncOnceIfAuthenticated()
     {
-        _user.Setup(x => x.Id).Returns(Guid.NewGuid().ToString());
+        _user.Id.Returns(Guid.NewGuid().ToString());
 
-        var requestLogger = new LoggingBehaviour<CreateTodoItemCommand>(_logger.Object, _user.Object, _identityService.Object);
+        var requestLogger = new LoggingBehaviour<CreateTodoItemCommand>(_logger, _user, _identityService);
 
         await requestLogger.Process(new CreateTodoItemCommand { ListId = 1, Title = "title" }, new CancellationToken());
 
-        _identityService.Verify(i => i.GetUserNameAsync(It.IsAny<string>()), Times.Once);
+        _ = _identityService.Received(1).GetUserNameAsync(Arg.Any<string>());
     }
 
     [Test]
     public async Task ShouldNotCallGetUserNameAsyncOnceIfUnauthenticated()
     {
-        var requestLogger = new LoggingBehaviour<CreateTodoItemCommand>(_logger.Object, _user.Object, _identityService.Object);
+        var requestLogger = new LoggingBehaviour<CreateTodoItemCommand>(_logger, _user, _identityService);
 
         await requestLogger.Process(new CreateTodoItemCommand { ListId = 1, Title = "title" }, new CancellationToken());
 
-        _identityService.Verify(i => i.GetUserNameAsync(It.IsAny<string>()), Times.Never);
+        _ = _identityService.Received(0).GetUserNameAsync(Arg.Any<string>());
     }
 }


### PR DESCRIPTION
Replace Moq with NSubstitute due to SponsorLink dependency in the…latest version.

https://www.bleepingcomputer.com/news/security/popular-open-source-project-moq-criticized-for-quietly-collecting-data/