### PR TITLE
🔥 Removed UseMigrationsEndPoint feature.

### DIFF
--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -14,7 +14,6 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-    app.UseMigrationsEndPoint();
     await app.InitialiseDatabaseAsync();
 }
 else


### PR DESCRIPTION
I propose removing the migration endpoint. Currently, the migration endpoint is only added when the application is in the `IsDevelopment()` environment. However, we already have automatic database migration implemented through the `InitialiseDatabaseAsync()` → `InitialiseAsync()` → `MigrateAsync()` flow. As a result, the migration endpoint is redundant and can be safely removed.