### PR TITLE
Fix randomization bug in GenerateRandomPassword function.

### DIFF
--- a/.scripts/setup.ps1
+++ b/.scripts/setup.ps1
@@ -170,7 +170,7 @@ function GenerateRandomPassword {
     [int]$Length = 16
   )
 
-  $ValidChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#^_-+=?<>|~"
+  $ValidChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#^_-+=?<>|~".ToCharArray()
   $Password = -join ((Get-Random -Count $Length -InputObject $ValidChars) | Get-Random -Count $Length)
 
   return $Password


### PR DESCRIPTION
The function GenerateRandomPassword always return same output as the defined valid chars without applying any randomization.

// Testing done by executing the function in PowerShell

Input
```
GenerateRandomPassword
GenerateRandomPassword 5
```
Output (Bug)
```
ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#^_-+=?<>|~
ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#^_-+=?<>|~
```
Output after fix
```
Z230b>?muoy54aQW
3|VFC
```

