### PR TITLE
Fix description of allowed environment names in main bicep

### DIFF
--- a/.azure/bicep/main.bicep
+++ b/.azure/bicep/main.bicep
@@ -1,7 +1,7 @@
 @description('The location into which your Azure resources should be deployed.')
 param location string = resourceGroup().location
 
-@description('Select the type of environment you want to provision. Allowed values are Production and Test.')
+@description('Select the type of environment you want to provision. Allowed values are Production, Staging, and Development.')
 @allowed([
   'Production'
   'Staging'


### PR DESCRIPTION
This _appears_ to be a trivial oversight from July's change to this file. Cheers.