### PR TITLE
chore: use System.HashCode struct to generate hash code instead of XOR values

### DIFF
--- a/src/Domain/Common/ValueObject.cs
+++ b/src/Domain/Common/ValueObject.cs
@@ -33,8 +33,13 @@ public abstract class ValueObject
 
     public override int GetHashCode()
     {
-        return GetEqualityComponents()
-            .Select(x => x != null ? x.GetHashCode() : 0)
-            .Aggregate((x, y) => x ^ y);
+        var hash = new HashCode();
+
+        foreach (var component in GetEqualityComponents())
+        {
+            hash.Add(component);
+        }
+
+        return hash.ToHashCode();
     }
 }


### PR DESCRIPTION
[I recommend to use HashCode ](https://stackoverflow.com/a/51716512/2618513)

> Pros:
> 
> - Part of .NET itself, as of .NET Core 2.1/.NET Standard 2.1 (though, see con below)
>     - For .NET Framework 4.6.1 and later, the [Microsoft.Bcl.HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode) NuGet package can be used to backport this type.
> - Looks to have good performance and mixing characteristics, based on the work the author and the reviewers did before [merging this into the corefx repo](https://github.com/dotnet/coreclr/pull/14863)
> - Handles nulls automatically
> - Overloads that take [IEqualityComparer](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.iequalitycomparer-1?view=netcore-2.1) instances
