### PR TITLE
Use the Created DateTimeOffset for initial LastModified in MainAuditableEntityInterceptor.UpdateEntities

### DIFF
--- a/src/Infrastructure/Data/Interceptors/AuditableEntityInterceptor.cs
+++ b/src/Infrastructure/Data/Interceptors/AuditableEntityInterceptor.cs
@@ -39,16 +39,16 @@ public class AuditableEntityInterceptor : SaveChangesInterceptor
 
         foreach (var entry in context.ChangeTracker.Entries<BaseAuditableEntity>())
         {
-            if (entry.State == EntityState.Added)
-            {
-                entry.Entity.CreatedBy = _user.Id;
-                entry.Entity.Created = _dateTime.GetUtcNow();
-            } 
-
             if (entry.State == EntityState.Added || entry.State == EntityState.Modified || entry.HasChangedOwnedEntities())
             {
+                var utcNow = _dateTime.GetUtcNow();
+                if (entry.State == EntityState.Added)
+                {
+                    entry.Entity.CreatedBy = _user.Id;
+                    entry.Entity.Created = utcNow;
+                } 
                 entry.Entity.LastModifiedBy = _user.Id;
-                entry.Entity.LastModified = _dateTime.GetUtcNow();
+                entry.Entity.LastModified = utcNow;
             }
         }
     }

--- a/src/Infrastructure/Data/Interceptors/AuditableEntityInterceptor.cs
+++ b/src/Infrastructure/Data/Interceptors/AuditableEntityInterceptor.cs
@@ -39,7 +39,7 @@ public class AuditableEntityInterceptor : SaveChangesInterceptor
 
         foreach (var entry in context.ChangeTracker.Entries<BaseAuditableEntity>())
         {
-            if (entry.State == EntityState.Added || entry.State == EntityState.Modified || entry.HasChangedOwnedEntities())
+            if (entry.State is EntityState.Added or EntityState.Modified || entry.HasChangedOwnedEntities())
             {
                 var utcNow = _dateTime.GetUtcNow();
                 if (entry.State == EntityState.Added)


### PR DESCRIPTION
Seems more correct to have the initial LastModifiedBy timestamp exactly equal the CreatedBy timestamp rather than being very slightly later with an additional call to _dateTime.GetUtcNow()