### PR TITLE
Fix override OnModelCreating

### DIFF
--- a/src/Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/Data/ApplicationDbContext.cs
@@ -17,8 +17,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>, IApplica
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
-        builder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
-
         base.OnModelCreating(builder);
+        builder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
     }
 }


### PR DESCRIPTION
Follow this [post](https://learn.microsoft.com/en-us/aspnet/core/security/authentication/customize-identity-model?view=aspnetcore-2.2) and this [issue](https://github.com/dotnet/efcore/issues/9503#issuecomment-431318312)

This will fix issues related to custom TKey in Identity

> When overriding OnModelCreating, base.OnModelCreating should be called first; the overriding configuration should be called next. EF Core generally has a last-one-wins policy for configuration. For example, if the ToTable method for an entity type is called first with one table name and then again later with a different table name, the table name in the second call is used.

When trying to customize identity