### PR TITLE
Replace System.Runtime.Serialization GetUninitializedObject method

### DIFF
--- a/tests/Application.UnitTests/Common/Mappings/MappingTests.cs
+++ b/tests/Application.UnitTests/Common/Mappings/MappingTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using AutoMapper;
 using CleanArchitecture.Application.Common.Interfaces;
 using CleanArchitecture.Application.Common.Models;
@@ -48,9 +48,6 @@ public class MappingTests
             return Activator.CreateInstance(type)!;
 
         // Type without parameterless constructor
-        // TODO: Figure out an alternative approach to the now obsolete `FormatterServices.GetUninitializedObject` method.
-#pragma warning disable SYSLIB0050 // Type or member is obsolete
-        return FormatterServices.GetUninitializedObject(type);
-#pragma warning restore SYSLIB0050 // Type or member is obsolete
+        return RuntimeHelpers.GetUninitializedObject(type);
     }
 }


### PR DESCRIPTION
Replaces obsolete `System.Runtime.Serialization` `FormatterServices.GetUninitializedObject` reference in MappingTests with equivalent version in `System.Runtime.CompilerServices`.

Based on the workaround described here:

https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0050#workaround