### PR TITLE
Add missing .editorconfig settings for Javascript

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,10 @@ indent_style = space
 [*.{xml,csproj,props,targets,ruleset,nuspec,resx}]
 indent_size = 2
 
+# Javascript files
+[*.js]
+indent_size = 2
+
 # Json files
 [*.{json,config,nswag}]
 indent_size = 2


### PR DESCRIPTION
Makes indentation consistent across all IDEs when working with Javascript files.