### PR TITLE
IdentityService.cs - use FindByIdAsync

### DIFF
--- a/src/Infrastructure/Identity/IdentityService.cs
+++ b/src/Infrastructure/Identity/IdentityService.cs
@@ -1,4 +1,4 @@
-﻿using CleanArchitecture.Application.Common.Interfaces;
+using CleanArchitecture.Application.Common.Interfaces;
 using CleanArchitecture.Application.Common.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -24,9 +24,9 @@ public class IdentityService : IIdentityService
 
     public async Task<string?> GetUserNameAsync(string userId)
     {
-        var user = await _userManager.Users.FirstAsync(u => u.Id == userId);
+        var user = await _userManager.FindByIdAsync(userId);
 
-        return user.UserName;
+        return user?.UserName;
     }
 
     public async Task<(Result Result, string UserId)> CreateUserAsync(string userName, string password)
@@ -44,14 +44,14 @@ public class IdentityService : IIdentityService
 
     public async Task<bool> IsInRoleAsync(string userId, string role)
     {
-        var user = _userManager.Users.SingleOrDefault(u => u.Id == userId);
+        var user = await _userManager.FindByIdAsync(userId);
 
         return user != null && await _userManager.IsInRoleAsync(user, role);
     }
 
     public async Task<bool> AuthorizeAsync(string userId, string policyName)
     {
-        var user = _userManager.Users.SingleOrDefault(u => u.Id == userId);
+        var user = await _userManager.FindByIdAsync(userId);
 
         if (user == null)
         {
@@ -67,7 +67,7 @@ public class IdentityService : IIdentityService
 
     public async Task<Result> DeleteUserAsync(string userId)
     {
-        var user = _userManager.Users.SingleOrDefault(u => u.Id == userId);
+        var user = await _userManager.FindByIdAsync(userId);
 
         return user != null ? await DeleteUserAsync(user) : Result.Success();
     }


### PR DESCRIPTION
Changing to FindByIdAsync means EF doesn't send the same database query over and over when querying the same user's information in the same request. For SQL UserStore at least: https://github.com/dotnet/aspnetcore/blob/5c17b92560953e86f1ea8502a567bcb3a1be4a2f/src/Identity/EntityFrameworkCore/src/UserStore.cs#L219

Improves #1046, see my comment there.