### PR TITLE
Fix readme invalid repository url on project creation

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -1,6 +1,6 @@
 ﻿# CleanArchitecture
 
-The project was generated using the [Clean.Architecture.Solution.Template](https://github.com/jasontaylordev/CleanArchitecture) version caPackageVersion.
+The project was generated using the [Clean.Architecture.Solution.Template](caRepositoryUrl) version caPackageVersion.
 
 ## Build
 
@@ -39,7 +39,7 @@ Create a new query:
 dotnet new ca-usecase -n GetTodos -fn TodoLists -ut query -rt TodosVm
 ```
 
-If you encounter the error *"No templates or subcommands found matching: 'ca-usecase'."*, install the template and try again:
+If you encounter the error _"No templates or subcommands found matching: 'ca-usecase'."_, install the template and try again:
 
 ```bash
 dotnet new install Clean.Architecture.Solution.Template::caPackageVersion
@@ -48,16 +48,21 @@ dotnet new install Clean.Architecture.Solution.Template::caPackageVersion
 ## Test
 
 <!--#if (UseApiOnly) -->
+
 The solution contains unit, integration, and functional tests.
 
 To run the tests:
+
 ```bash
 dotnet test
 ```
+
 <!--#else -->
+
 The solution contains unit, integration, functional, and acceptance tests.
 
 To run the unit, integration, and functional tests (excluding acceptance tests):
+
 ```bash
 dotnet test --filter "FullyQualifiedName!~AcceptanceTests"
 ```
@@ -70,11 +75,14 @@ dotnet run
 ```
 
 Then, in a new console, run the tests:
+
 ```bash
 cd .\src\Web\
 dotnet test
 ```
+
 <!--#endif -->
 
 ## Help
+
 To learn more about the template go to the [project website](caRepositoryUrl). Here you can find additional guidance, request new features, report a bug, and discuss the template with other users.


### PR DESCRIPTION
 When calling this template via `dotnet new ca-sln -n XYZ`, the resulting project will contain a readme with an invalid repo url.

So this line in [README-template.md](https://github.com/jasontaylordev/CleanArchitecture/blob/main/README-template.md)

> The project was generated using the [Clean.Architecture.Solution.Template](https://github.com/jasontaylordev/CleanArchitecture) version caPackageVersion.

will turn into

> The project was generated using the [Clean.Architecture.Solution.Template](https://github.com/jasontaylordev/XYZ) version caPackageVersion.

That is not supposed to happen. I fixed this by injecting `caRepositoryUrl` into [README-template.md](https://github.com/jasontaylordev/CleanArchitecture/blob/main/README-template.md).
