### PR TITLE
Integration Tests for Entity CRUD Operations in CleanArchitecture.Infrastructure

### DIFF
--- a/tests/Infrastructure.IntegrationTests/Data/BaseEfRepoTestFixture.cs
+++ b/tests/Infrastructure.IntegrationTests/Data/BaseEfRepoTestFixture.cs
@@ -1,0 +1,37 @@
+﻿using CleanArchitecture.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CleanArchitecture.Infrastructure.IntegrationTests.Data;
+
+[TestFixture]
+public abstract class BaseEfRepoTestFixture
+{
+    protected ApplicationDbContext dbContext;
+
+    protected BaseEfRepoTestFixture()
+    {
+        var options = CreateNewContextOptions();
+        dbContext = new ApplicationDbContext(options);
+        dbContext.Database.OpenConnection(); // Ensure the connection is opened
+        dbContext.Database.EnsureCreated(); // Ensure the database schema is created
+    }
+
+    protected static DbContextOptions<ApplicationDbContext> CreateNewContextOptions()
+    {
+        // Create a fresh service provider, and therefore a fresh
+        // SQLite database instance.
+        var serviceProvider = new ServiceCollection()
+            .AddEntityFrameworkSqlite()
+            .BuildServiceProvider();
+
+        // Create a new options instance telling the context to use a
+        // SQLite database and the new service provider.
+        var builder = new DbContextOptionsBuilder<ApplicationDbContext>();
+        builder.UseSqlite("DataSource=:memory:")
+               .UseInternalServiceProvider(serviceProvider);
+
+        return builder.Options;
+    }
+
+}

--- a/tests/Infrastructure.IntegrationTests/Data/EfRepositoryAdd.cs
+++ b/tests/Infrastructure.IntegrationTests/Data/EfRepositoryAdd.cs
@@ -1,0 +1,61 @@
+﻿using CleanArchitecture.Domain.Entities;
+using CleanArchitecture.Domain.ValueObjects;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+
+namespace CleanArchitecture.Infrastructure.IntegrationTests.Data;
+
+public class EfRepositoryAdd : BaseEfRepoTestFixture
+{
+    [Test]
+    public async Task AddEntity_ShouldNotPersistWithoutSaveChanges()
+    {
+        // Arrange
+        var todoName = "Test Name";
+        var todoColor = Colour.Blue;
+
+        var todoList = new TodoList()
+        {
+            Title = todoName,
+            Colour = todoColor,
+        };
+
+        // Act
+        await dbContext.AddAsync(todoList);
+
+        // Assert before SaveChanges
+        var entityEntry = dbContext.Entry(todoList);
+        entityEntry.State.Should().Be(EntityState.Added);
+
+        // Optionally, you can also check if it is in the context
+        var newTodo = await dbContext.TodoLists.FirstOrDefaultAsync(t => t.Title == todoName);
+        newTodo.Should().BeNull("because the changes have not been saved to the database yet.");
+    }
+
+    [Test]
+    public async Task AddEntity_ShouldPersistAfterSaveChanges()
+    {
+        // Arrange
+        var todoName = "Test Name";
+        var todoColor = Colour.Blue;
+
+        var todoList = new TodoList()
+        {
+            Title = todoName,
+            Colour = todoColor,
+        };
+
+        // Act
+        await dbContext.AddAsync(todoList);
+        await dbContext.SaveChangesAsync();
+
+        // Assert
+        var newTodo = await dbContext.TodoLists.FirstOrDefaultAsync();
+
+        newTodo.Should().NotBeNull();
+        newTodo?.Title.Should().NotBeNull();
+        newTodo?.Title.Should().Be(todoName);
+        newTodo?.Colour.Code.Should().Be(todoColor.Code);
+    }
+
+}

--- a/tests/Infrastructure.IntegrationTests/Data/EfRepositoryDelete.cs
+++ b/tests/Infrastructure.IntegrationTests/Data/EfRepositoryDelete.cs
@@ -1,0 +1,118 @@
+﻿using CleanArchitecture.Domain.Entities;
+using CleanArchitecture.Domain.ValueObjects;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+
+namespace CleanArchitecture.Infrastructure.IntegrationTests.Data;
+
+public class EfRepositoryDelete : BaseEfRepoTestFixture
+{
+    [Test]
+    public async Task AddEntity_ShouldNotPersistWithoutSaveChanges()
+    {
+        // Arrange
+        var todoName = "Test Name";
+        var todoColor = Colour.Blue;
+
+        var todoList = new TodoList()
+        {
+            Title = todoName,
+            Colour = todoColor,
+        };
+
+        // Act
+        await dbContext.AddAsync(todoList);
+
+        // Assert before SaveChanges
+        var entityEntry = dbContext.Entry(todoList);
+        entityEntry.State.Should().Be(EntityState.Added);
+
+        // Optionally, you can also check if it is in the context
+        var newTodo = await dbContext.TodoLists.FirstOrDefaultAsync(t => t.Title == todoName);
+        newTodo.Should().BeNull("because the changes have not been saved to the database yet.");
+    }
+
+    [Test]
+    public async Task AddEntity_ShouldPersistAfterSaveChanges()
+    {
+        // Arrange
+        var todoName = "Test Name";
+        var todoColor = Colour.Blue;
+
+        var todoList = new TodoList()
+        {
+            Title = todoName,
+            Colour = todoColor,
+        };
+
+        // Act
+        await dbContext.AddAsync(todoList);
+        await dbContext.SaveChangesAsync();
+
+        // Assert after SaveChanges
+        var newTodo = await dbContext.TodoLists.FirstOrDefaultAsync();
+
+        newTodo.Should().NotBeNull();
+        newTodo?.Title.Should().NotBeNull();
+        newTodo?.Title.Should().Be(todoName);
+        newTodo?.Colour.Code.Should().Be(todoColor.Code);
+    }
+
+    [Test]
+    public async Task UpdateEntity_ShouldPersistChangesAfterSaveChanges()
+    {
+        // Arrange
+        var initialName = "Initial Name";
+        var updatedName = "Updated Name";
+        var todoColor = Colour.Blue;
+
+        var todoList = new TodoList()
+        {
+            Title = initialName,
+            Colour = todoColor,
+        };
+
+        // Add the entity to the database
+        await dbContext.AddAsync(todoList);
+        await dbContext.SaveChangesAsync();
+
+        // Act
+        todoList.Title = updatedName;
+        dbContext.Update(todoList);
+        await dbContext.SaveChangesAsync();
+
+        // Assert
+        var updatedTodo = await dbContext.TodoLists.FirstOrDefaultAsync(t => t.Id == todoList.Id);
+
+        updatedTodo.Should().NotBeNull();
+        updatedTodo?.Title.Should().NotBeNull();
+        updatedTodo?.Title.Should().Be(updatedName);
+    }
+
+    [Test]
+    public async Task DeleteEntity_ShouldRemoveEntityAfterSaveChanges()
+    {
+        // Arrange
+        var todoName = "Test Name";
+        var todoColor = Colour.Blue;
+
+        var todoList = new TodoList()
+        {
+            Title = todoName,
+            Colour = todoColor,
+        };
+
+        // Add the entity to the database
+        await dbContext.AddAsync(todoList);
+        await dbContext.SaveChangesAsync();
+
+        // Act
+        dbContext.Remove(todoList);
+        await dbContext.SaveChangesAsync();
+
+        // Assert
+        var deletedTodo = await dbContext.TodoLists.FirstOrDefaultAsync(t => t.Id == todoList.Id);
+        deletedTodo.Should().BeNull("because the entity has been deleted.");
+    }
+
+}

--- a/tests/Infrastructure.IntegrationTests/Data/EfRepositoryUpdate.cs
+++ b/tests/Infrastructure.IntegrationTests/Data/EfRepositoryUpdate.cs
@@ -1,0 +1,92 @@
+﻿using CleanArchitecture.Domain.Entities;
+using CleanArchitecture.Domain.ValueObjects;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+
+namespace CleanArchitecture.Infrastructure.IntegrationTests.Data;
+
+public class EfRepositoryUpdate : BaseEfRepoTestFixture
+{
+    [Test]
+    public async Task AddEntity_ShouldNotPersistWithoutSaveChanges()
+    {
+        // Arrange
+        var todoName = "Test Name";
+        var todoColor = Colour.Blue;
+
+        var todoList = new TodoList()
+        {
+            Title = todoName,
+            Colour = todoColor,
+        };
+
+        // Act
+        await dbContext.AddAsync(todoList);
+
+        // Assert before SaveChanges
+        var entityEntry = dbContext.Entry(todoList);
+        entityEntry.State.Should().Be(EntityState.Added);
+
+        // Optionally, you can also check if it is in the context
+        var newTodo = await dbContext.TodoLists.FirstOrDefaultAsync(t => t.Title == todoName);
+        newTodo.Should().BeNull("because the changes have not been saved to the database yet.");
+    }
+
+    [Test]
+    public async Task AddEntity_ShouldPersistAfterSaveChanges()
+    {
+        // Arrange
+        var todoName = "Test Name";
+        var todoColor = Colour.Blue;
+
+        var todoList = new TodoList()
+        {
+            Title = todoName,
+            Colour = todoColor,
+        };
+
+        // Act
+        await dbContext.AddAsync(todoList);
+        await dbContext.SaveChangesAsync();
+
+        // Assert after SaveChanges
+        var newTodo = await dbContext.TodoLists.FirstOrDefaultAsync();
+
+        newTodo.Should().NotBeNull();
+        newTodo?.Title.Should().NotBeNull();
+        newTodo?.Title.Should().Be(todoName);
+        newTodo?.Colour.Code.Should().Be(todoColor.Code);
+    }
+
+    [Test]
+    public async Task UpdateEntity_ShouldPersistChangesAfterSaveChanges()
+    {
+        // Arrange
+        var initialName = "Initial Name";
+        var updatedName = "Updated Name";
+        var todoColor = Colour.Blue;
+
+        var todoList = new TodoList()
+        {
+            Title = initialName,
+            Colour = todoColor,
+        };
+
+        // Add the entity to the database
+        await dbContext.AddAsync(todoList);
+        await dbContext.SaveChangesAsync();
+
+        // Act
+        todoList.Title = updatedName;
+        dbContext.Update(todoList);
+        await dbContext.SaveChangesAsync();
+
+        // Assert
+        var updatedTodo = await dbContext.TodoLists.FirstOrDefaultAsync(t => t.Id == todoList.Id);
+
+        updatedTodo.Should().NotBeNull();
+        updatedTodo?.Title.Should().NotBeNull();
+        updatedTodo?.Title.Should().Be(updatedName);
+    }
+
+}

--- a/tests/Infrastructure.IntegrationTests/Infrastructure.IntegrationTests.csproj
+++ b/tests/Infrastructure.IntegrationTests/Infrastructure.IntegrationTests.csproj
@@ -1,22 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <RootNamespace>CleanArchitecture.Infrastructure.IntegrationTests</RootNamespace>
-        <AssemblyName>CleanArchitecture.Infrastructure.IntegrationTests</AssemblyName>
-    </PropertyGroup>
+  <PropertyGroup>
+    <RootNamespace>CleanArchitecture.Infrastructure.IntegrationTests</RootNamespace>
+    <AssemblyName>CleanArchitecture.Infrastructure.IntegrationTests</AssemblyName>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="NUnit" />
-        <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="NUnit.Analyzers">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Infrastructure\Infrastructure.csproj" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Integration Tests for Entity CRUD Operations in CleanArchitecture.Infrastructure

This pull request introduces integration tests for CRUD (Create, Read, Update, Delete) operations in the `CleanArchitecture.Infrastructure` project. The key changes and additions are as follows:

## Key Changes

### 1. BaseEfRepoTestFixture Class
- Provides a base class for integration tests, setting up an in-memory SQLite database for testing purposes.
- Ensures the database connection is opened and schema is created before tests are executed.

### 2. EfRepositoryAdd Class
- Contains tests to verify the behavior of adding entities to the database.
- Tests ensure that entities are not persisted without calling `SaveChanges` and are correctly persisted after calling `SaveChanges`.

### 3. EfRepositoryDelete Class
- Includes tests to validate the deletion of entities from the database.
- Tests ensure that entities are correctly removed after calling `SaveChanges`.

### 4. EfRepositoryUpdate Class
- Consists of tests to check the update functionality of entities.
- Tests ensure that updated entities are correctly persisted after calling `SaveChanges`.

## Summary

These integration tests are designed to enhance the robustness of the application by verifying the correct implementation of CRUD operations within the infrastructure layer. They provide a foundation for future tests and help ensure data consistency and reliability.

Please review the changes and provide feedback.
