### PR TITLE
Update codeql.yml to allow for private repositories to be checked-out.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,8 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       security-events: write
 
     steps:


### PR DESCRIPTION
Added additional permissions for the analyze job so the action is able to checkout the code of it is a private repository. Otherwise a "repository <repository> not found" error is displayed.