### PR TITLE
Optimize improve performance by using AnyAsync

### DIFF
--- a/src/Application/TodoLists/Commands/CreateTodoList/CreateTodoListCommandValidator.cs
+++ b/src/Application/TodoLists/Commands/CreateTodoList/CreateTodoListCommandValidator.cs
@@ -20,7 +20,7 @@ public class CreateTodoListCommandValidator : AbstractValidator<CreateTodoListCo
 
     public async Task<bool> BeUniqueTitle(string title, CancellationToken cancellationToken)
     {
-        return await _context.TodoLists
-            .AllAsync(l => l.Title != title, cancellationToken);
+        return !await _context.TodoLists
+            .AnyAsync(l => l.Title == title, cancellationToken);
     }
 }

--- a/src/Application/TodoLists/Commands/UpdateTodoList/UpdateTodoListCommandValidator.cs
+++ b/src/Application/TodoLists/Commands/UpdateTodoList/UpdateTodoListCommandValidator.cs
@@ -20,8 +20,8 @@ public class UpdateTodoListCommandValidator : AbstractValidator<UpdateTodoListCo
 
     public async Task<bool> BeUniqueTitle(UpdateTodoListCommand model, string title, CancellationToken cancellationToken)
     {
-        return await _context.TodoLists
+        return !await _context.TodoLists
             .Where(l => l.Id != model.Id)
-            .AllAsync(l => l.Title != title, cancellationToken);
+            .AnyAsync(l => l.Title == title, cancellationToken);
     }
 }


### PR DESCRIPTION
- Replaced the `AllAsync` method with `AnyAsync` in the `BeUniqueTitle` method of `CreateTodoListCommandValidator`.
- This change improves performance by stopping the query as soon as the first matching title is found, rather than checking all records.
- The new implementation checks if any `TodoList` record has a matching title, which is more efficient, especially for large datasets.

#### Changes:
- **Before**: 
  ```csharp
  return await _context.TodoLists
      .AllAsync(l => l.Title != title, cancellationToken);
  ```
- **After**: 
  ```csharp
  return !await _context.TodoLists
      .AnyAsync(l => l.Title == title, cancellationToken);
  ```

This optimization enhances performance when validating unique `Title` values.