### PR TITLE
🐛 Automatically create the https folder.

### DIFF
--- a/src/Web/ClientApp-React/aspnetcore-https.js
+++ b/src/Web/ClientApp-React/aspnetcore-https.js
@@ -8,6 +8,8 @@ const baseFolder =
     ? `${process.env.APPDATA}/ASP.NET/https`
     : `${process.env.HOME}/.aspnet/https`;
 
+if (!fs.existsSync(baseFolder)) { fs.mkdirSync(baseFolder, { recursive: true }); }
+
 const certificateArg = process.argv.map(arg => arg.match(/--name=(?<value>.+)/i)).filter(Boolean)[0];
 const certificateName = certificateArg ? certificateArg.groups.value : process.env.npm_package_name;
 

--- a/src/Web/ClientApp/aspnetcore-https.js
+++ b/src/Web/ClientApp/aspnetcore-https.js
@@ -8,6 +8,8 @@ const baseFolder =
     ? `${process.env.APPDATA}/ASP.NET/https`
     : `${process.env.HOME}/.aspnet/https`;
 
+if (!fs.existsSync(baseFolder)) { fs.mkdirSync(baseFolder, { recursive: true }); }
+
 const certificateArg = process.argv.map(arg => arg.match(/--name=(?<value>.+)/i)).filter(Boolean)[0];
 const certificateName = certificateArg ? certificateArg.groups.value : process.env.npm_package_name;
 


### PR DESCRIPTION
Fixes the issue mentioned in #1266 and #1247. For reference:

> There has been a breaking change to the behaviour of dotnet dev-certs, it no longer creates a file path if its missing.
> 
> In the npm start https prerun script aspnetcore-https.js it runs the dev-certs command but errors if the file path does not exist due to the behaviour change. Needs to be updated to instead check if the dir exists and create it instead.
> 
> Can see the changes documented here - [link](https://learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/9.0/certificate-export)




