### PR TITLE
Fix key vault secret name mismatch

### DIFF
--- a/infra/core/database/postgresql/flexibleserver.bicep
+++ b/infra/core/database/postgresql/flexibleserver.bicep
@@ -123,7 +123,7 @@ psql "host=$DBSERVER.postgres.database.azure.com user=$ADMINLOGIN dbname=$DBNAME
 
 resource administratorLoginPasswordSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
   parent: keyVault
-  name: 'administratorLoginPassword'
+  name: 'dbAdminPassword'
   properties: {
     value: administratorLoginPassword
   }
@@ -131,7 +131,7 @@ resource administratorLoginPasswordSecret 'Microsoft.KeyVault/vaults/secrets@202
 
 resource appUserLoginPasswordSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
   parent: keyVault
-  name: 'appUserLoginPassword'
+  name: 'dbAppUserPassword'
   properties: {
     value: appUserLoginPassword
   }

--- a/infra/core/database/sqlserver/sqlserver.bicep
+++ b/infra/core/database/sqlserver/sqlserver.bicep
@@ -173,7 +173,7 @@ SCRIPT_END
 
 resource sqlAdminPasswordSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
   parent: keyVault
-  name: 'sqlAdminPassword'
+  name: 'dbAdminPassword'
   properties: {
     value: sqlAdminPassword
   }
@@ -181,7 +181,7 @@ resource sqlAdminPasswordSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' =
 
 resource appUserPasswordSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
   parent: keyVault
-  name: 'appUserPassword'
+  name: 'dbAppUserPassword'
   properties: {
     value: appUserPassword
   }


### PR DESCRIPTION
Hey guys,

I've been having the issue that after each infrastructure deployment I had a new key vault secret version for the database passwords and connections string.

It sounds implausible that nobody else encountered this issue till now, so it can be that I'm missing something, but anyways, here's what I think is happening.

The key vault secret name for the database user and admin user in the main.parameters.json did not match the secret name in the [flexibleserver|sqlserver].bicep files.

The latter files are the ones that set the key vault secret names for the passwords. The main.parameters.json was referring to these secrets under different names, by which it never found a secret so it kept generating new passwords on each deployment. 

e.g.:
```
      "dbAppUserPassword": {
        "value": "$(secretOrRandomPassword ${AZURE_KEY_VAULT_NAME} dbAppUserPassword)"
      }

```

The password doesn't get updated in the DB once it's been created, but the secret did get updated to a new version, resulting in the connection string getting invalid starting with the second deployment.

