### PR TITLE
refactor: remove AutoMapper and replace with manual mapping due to licensing changes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,6 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
     <!--#endif-->
     <PackageVersion Include="Ardalis.GuardClauses" Version="4.6.0" />
-    <PackageVersion Include="AutoMapper" Version="13.0.1" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
     <PackageVersion Include="Azure.Identity" Version="1.13.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,6 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
     <PackageVersion Include="Azure.Identity" Version="1.13.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageVersion Include="MediatR" Version="12.4.1" />
@@ -49,6 +48,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EfcoreVersion)" />
     <!--#if (UsePostgreSQL)-->
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.1" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.0.0" />
     <!--#endif-->
     <!--#if (UseSqlite)-->

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ azd up
 * [Entity Framework Core 9](https://docs.microsoft.com/en-us/ef/core/)
 * [Angular 18](https://angular.dev/) or [React 18](https://react.dev/)
 * [MediatR](https://github.com/jbogard/MediatR)
-* [AutoMapper](https://automapper.org/)
 * [FluentValidation](https://fluentvalidation.net/)
 * [NUnit](https://nunit.org/), [Shoudly](https://docs.shouldly.org/), [Moq](https://github.com/devlooped/moq) & [Respawn](https://github.com/jbogard/Respawn)
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ azd up
 * [MediatR](https://github.com/jbogard/MediatR)
 * [AutoMapper](https://automapper.org/)
 * [FluentValidation](https://fluentvalidation.net/)
-* [NUnit](https://nunit.org/), [FluentAssertions](https://fluentassertions.com/), [Moq](https://github.com/devlooped/moq) & [Respawn](https://github.com/jbogard/Respawn)
+* [NUnit](https://nunit.org/), [Shoudly](https://docs.shouldly.org/), [Moq](https://github.com/devlooped/moq) & [Respawn](https://github.com/jbogard/Respawn)
 
 ## Versions
 The main branch is now on .NET 9.0. The following previous versions are available:

--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" />
-    <PackageReference Include="AutoMapper" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />

--- a/src/Application/Common/Mappings/MappingExtensions.cs
+++ b/src/Application/Common/Mappings/MappingExtensions.cs
@@ -4,9 +4,28 @@ namespace CleanArchitecture.Application.Common.Mappings;
 
 public static class MappingExtensions
 {
-    public static Task<PaginatedList<TDestination>> PaginatedListAsync<TDestination>(this IQueryable<TDestination> queryable, int pageNumber, int pageSize, CancellationToken cancellationToken = default) where TDestination : class
-        => PaginatedList<TDestination>.CreateAsync(queryable.AsNoTracking(), pageNumber, pageSize, cancellationToken);
+    public static Task<PaginatedList<TDestination>> PaginatedListAsync<TSource, TDestination>(
+        this IQueryable<TSource> queryable,
+        Func<TSource, TDestination> mapFunc,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+        where TSource : class
+        where TDestination : class
+    {
+        return PaginatedList<TDestination>.CreateAsync(queryable.AsNoTracking(), mapFunc, pageNumber, pageSize, cancellationToken);
+    }
 
-    public static Task<List<TDestination>> ProjectToListAsync<TDestination>(this IQueryable queryable, IConfigurationProvider configuration, CancellationToken cancellationToken = default) where TDestination : class
-        => queryable.ProjectTo<TDestination>(configuration).AsNoTracking().ToListAsync(cancellationToken);
+    public static async Task<List<TDestination>> ProjectToListAsync<TSource, TDestination>(
+        this IQueryable<TSource> queryable,
+        Func<TSource, TDestination> mapFunc,
+        CancellationToken cancellationToken = default)
+        where TSource : class
+        where TDestination : class
+    {
+        return await queryable
+            .AsNoTracking()
+            .Select(x => mapFunc(x))
+            .ToListAsync(cancellationToken);
+    }
 }

--- a/src/Application/Common/Models/LookupDto.cs
+++ b/src/Application/Common/Models/LookupDto.cs
@@ -7,13 +7,19 @@ public class LookupDto
     public int Id { get; init; }
 
     public string? Title { get; init; }
+}
 
-    private class Mapping : Profile
+public static class LookupDtoMapper
+{
+    public static LookupDto FromTodoList(TodoList list) => new()
     {
-        public Mapping()
-        {
-            CreateMap<TodoList, LookupDto>();
-            CreateMap<TodoItem, LookupDto>();
-        }
-    }
+        Id = list.Id,
+        Title = list.Title
+    };
+
+    public static LookupDto FromTodoItem(TodoItem item) => new()
+    {
+        Id = item.Id,
+        Title = item.Title
+    };
 }

--- a/src/Application/Common/Models/PaginatedList.cs
+++ b/src/Application/Common/Models/PaginatedList.cs
@@ -19,11 +19,16 @@ public class PaginatedList<T>
 
     public bool HasNextPage => PageNumber < TotalPages;
 
-    public static async Task<PaginatedList<T>> CreateAsync(IQueryable<T> source, int pageNumber, int pageSize, CancellationToken cancellationToken = default)
+    public static async Task<PaginatedList<TDestination>> CreateAsync<TSource, TDestination>(
+        IQueryable<TSource> source,
+        Func<TSource, TDestination> mapFunc,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken = default)
     {
         var count = await source.CountAsync(cancellationToken);
         var items = await source.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToListAsync(cancellationToken);
-
-        return new PaginatedList<T>(items, count, pageNumber, pageSize);
+        var mappedItems = items.Select(mapFunc).ToList();
+        return new PaginatedList<TDestination>(mappedItems, count, pageNumber, pageSize);
     }
 }

--- a/src/Application/DependencyInjection.cs
+++ b/src/Application/DependencyInjection.cs
@@ -8,8 +8,6 @@ public static class DependencyInjection
 {
     public static void AddApplicationServices(this IHostApplicationBuilder builder)
     {
-        builder.Services.AddAutoMapper(Assembly.GetExecutingAssembly());
-
         builder.Services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
 
         builder.Services.AddMediatR(cfg => {

--- a/src/Application/GlobalUsings.cs
+++ b/src/Application/GlobalUsings.cs
@@ -1,6 +1,4 @@
 ﻿global using Ardalis.GuardClauses;
-global using AutoMapper;
-global using AutoMapper.QueryableExtensions;
 global using Microsoft.EntityFrameworkCore;
 global using FluentValidation;
 global using MediatR;

--- a/src/Application/TodoItems/Queries/GetTodoItemsWithPagination/GetTodoItemsWithPagination.cs
+++ b/src/Application/TodoItems/Queries/GetTodoItemsWithPagination/GetTodoItemsWithPagination.cs
@@ -14,20 +14,17 @@ public record GetTodoItemsWithPaginationQuery : IRequest<PaginatedList<TodoItemB
 public class GetTodoItemsWithPaginationQueryHandler : IRequestHandler<GetTodoItemsWithPaginationQuery, PaginatedList<TodoItemBriefDto>>
 {
     private readonly IApplicationDbContext _context;
-    private readonly IMapper _mapper;
 
-    public GetTodoItemsWithPaginationQueryHandler(IApplicationDbContext context, IMapper mapper)
+    public GetTodoItemsWithPaginationQueryHandler(IApplicationDbContext context)
     {
         _context = context;
-        _mapper = mapper;
     }
 
     public async Task<PaginatedList<TodoItemBriefDto>> Handle(GetTodoItemsWithPaginationQuery request, CancellationToken cancellationToken)
     {
         return await _context.TodoItems
-            .Where(x => x.ListId == request.ListId)
-            .OrderBy(x => x.Title)
-            .ProjectTo<TodoItemBriefDto>(_mapper.ConfigurationProvider)
-            .PaginatedListAsync(request.PageNumber, request.PageSize, cancellationToken);
+               .Where(x => x.ListId == request.ListId)
+               .OrderBy(x => x.Title)
+               .PaginatedListAsync(TodoItemBriefDtoMapper.FromEntity, request.PageNumber, request.PageSize, cancellationToken);
     }
 }

--- a/src/Application/TodoItems/Queries/GetTodoItemsWithPagination/TodoItemBriefDto.cs
+++ b/src/Application/TodoItems/Queries/GetTodoItemsWithPagination/TodoItemBriefDto.cs
@@ -11,12 +11,15 @@ public class TodoItemBriefDto
     public string? Title { get; init; }
 
     public bool Done { get; init; }
+}
 
-    private class Mapping : Profile
+public static class TodoItemBriefDtoMapper
+{
+    public static TodoItemBriefDto FromEntity(TodoItem item) => new()
     {
-        public Mapping()
-        {
-            CreateMap<TodoItem, TodoItemBriefDto>();
-        }
-    }
+        Id = item.Id,
+        ListId = item.ListId,
+        Title = item.Title,
+        Done = item.Done
+    };
 }

--- a/src/Application/TodoLists/Queries/GetTodos/TodoItemDto.cs
+++ b/src/Application/TodoLists/Queries/GetTodos/TodoItemDto.cs
@@ -15,13 +15,18 @@ public class TodoItemDto
     public int Priority { get; init; }
 
     public string? Note { get; init; }
+}
 
-    private class Mapping : Profile
+
+public static class TodoItemDtoMapper
+{
+    public static TodoItemDto FromEntity(TodoItem item) => new()
     {
-        public Mapping()
-        {
-            CreateMap<TodoItem, TodoItemDto>().ForMember(d => d.Priority, 
-                opt => opt.MapFrom(s => (int)s.Priority));
-        }
-    }
+        Id = item.Id,
+        ListId = item.ListId,
+        Title = item.Title,
+        Done = item.Done,
+        Priority = (int)item.Priority,
+        Note = item.Note
+    };
 }

--- a/src/Application/TodoLists/Queries/GetTodos/TodoListDto.cs
+++ b/src/Application/TodoLists/Queries/GetTodos/TodoListDto.cs
@@ -16,12 +16,18 @@ public class TodoListDto
     public string? Colour { get; init; }
 
     public IReadOnlyCollection<TodoItemDto> Items { get; init; }
+}
 
-    private class Mapping : Profile
+public static class TodoListDtoMapper
+{
+    public static TodoListDto FromEntity(TodoList list) => new()
     {
-        public Mapping()
-        {
-            CreateMap<TodoList, TodoListDto>();
-        }
-    }
+        Id = list.Id,
+        Title = list.Title,
+        Colour = list.Colour,
+        Items = list.Items?
+            .Select(TodoItemDtoMapper.FromEntity)
+            .ToList()
+            ?? new List<TodoItemDto>()
+    };
 }

--- a/tests/Application.FunctionalTests/Application.FunctionalTests.csproj
+++ b/tests/Application.FunctionalTests/Application.FunctionalTests.csproj
@@ -32,9 +32,9 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="FluentAssertions" />
       <PackageReference Include="Moq" />
       <PackageReference Include="Respawn" />
+      <PackageReference Include="Shouldly" />
       <PackageReference Include="System.Configuration.ConfigurationManager" />
       <!--#if (UsePostgreSQL)-->
       <PackageReference Include="Testcontainers.PostgreSql" />

--- a/tests/Application.FunctionalTests/GlobalUsings.cs
+++ b/tests/Application.FunctionalTests/GlobalUsings.cs
@@ -1,4 +1,4 @@
 ﻿global using Ardalis.GuardClauses;
-global using FluentAssertions;
+global using Shouldly;
 global using Moq;
 global using NUnit.Framework;

--- a/tests/Application.FunctionalTests/TodoItems/Commands/CreateTodoItemTests.cs
+++ b/tests/Application.FunctionalTests/TodoItems/Commands/CreateTodoItemTests.cs
@@ -14,8 +14,7 @@ public class CreateTodoItemTests : BaseTestFixture
     {
         var command = new CreateTodoItemCommand();
 
-        await FluentActions.Invoking(() =>
-            SendAsync(command)).Should().ThrowAsync<ValidationException>();
+        await Should.ThrowAsync<ValidationException>(() => SendAsync(command));
     }
 
     [Test]
@@ -38,12 +37,12 @@ public class CreateTodoItemTests : BaseTestFixture
 
         var item = await FindAsync<TodoItem>(itemId);
 
-        item.Should().NotBeNull();
-        item!.ListId.Should().Be(command.ListId);
-        item.Title.Should().Be(command.Title);
-        item.CreatedBy.Should().Be(userId);
-        item.Created.Should().BeCloseTo(DateTime.Now, TimeSpan.FromMilliseconds(10000));
-        item.LastModifiedBy.Should().Be(userId);
-        item.LastModified.Should().BeCloseTo(DateTime.Now, TimeSpan.FromMilliseconds(10000));
+        item.ShouldNotBeNull();
+        item!.ListId.ShouldBe(command.ListId);
+        item.Title.ShouldBe(command.Title);
+        item.CreatedBy.ShouldBe(userId);
+        item.Created.ShouldBe(DateTime.Now, TimeSpan.FromMilliseconds(10000));
+        item.LastModifiedBy.ShouldBe(userId);
+        item.LastModified.ShouldBe(DateTime.Now, TimeSpan.FromMilliseconds(10000));
     }
 }

--- a/tests/Application.FunctionalTests/TodoItems/Commands/DeleteTodoItemTests.cs
+++ b/tests/Application.FunctionalTests/TodoItems/Commands/DeleteTodoItemTests.cs
@@ -14,8 +14,7 @@ public class DeleteTodoItemTests : BaseTestFixture
     {
         var command = new DeleteTodoItemCommand(99);
 
-        await FluentActions.Invoking(() =>
-            SendAsync(command)).Should().ThrowAsync<NotFoundException>();
+        await Should.ThrowAsync<NotFoundException>(() => SendAsync(command));
     }
 
     [Test]
@@ -36,6 +35,6 @@ public class DeleteTodoItemTests : BaseTestFixture
 
         var item = await FindAsync<TodoItem>(itemId);
 
-        item.Should().BeNull();
+        item.ShouldBeNull();
     }
 }

--- a/tests/Application.FunctionalTests/TodoItems/Commands/UpdateTodoItemDetailTests.cs
+++ b/tests/Application.FunctionalTests/TodoItems/Commands/UpdateTodoItemDetailTests.cs
@@ -15,7 +15,8 @@ public class UpdateTodoItemDetailTests : BaseTestFixture
     public async Task ShouldRequireValidTodoItemId()
     {
         var command = new UpdateTodoItemCommand { Id = 99, Title = "New Title" };
-        await FluentActions.Invoking(() => SendAsync(command)).Should().ThrowAsync<NotFoundException>();
+
+        await Should.ThrowAsync<NotFoundException>(() => SendAsync(command));
     }
 
     [Test]
@@ -46,12 +47,12 @@ public class UpdateTodoItemDetailTests : BaseTestFixture
 
         var item = await FindAsync<TodoItem>(itemId);
 
-        item.Should().NotBeNull();
-        item!.ListId.Should().Be(command.ListId);
-        item.Note.Should().Be(command.Note);
-        item.Priority.Should().Be(command.Priority);
-        item.LastModifiedBy.Should().NotBeNull();
-        item.LastModifiedBy.Should().Be(userId);
-        item.LastModified.Should().BeCloseTo(DateTime.Now, TimeSpan.FromMilliseconds(10000));
+        item.ShouldNotBeNull();
+        item!.ListId.ShouldBe(command.ListId);
+        item.Note.ShouldBe(command.Note);
+        item.Priority.ShouldBe(command.Priority);
+        item.LastModifiedBy.ShouldNotBeNull();
+        item.LastModifiedBy.ShouldBe(userId);
+        item.LastModified.ShouldBe(DateTime.Now, TimeSpan.FromMilliseconds(10000));
     }
 }

--- a/tests/Application.FunctionalTests/TodoItems/Commands/UpdateTodoItemTests.cs
+++ b/tests/Application.FunctionalTests/TodoItems/Commands/UpdateTodoItemTests.cs
@@ -13,7 +13,7 @@ public class UpdateTodoItemTests : BaseTestFixture
     public async Task ShouldRequireValidTodoItemId()
     {
         var command = new UpdateTodoItemCommand { Id = 99, Title = "New Title" };
-        await FluentActions.Invoking(() => SendAsync(command)).Should().ThrowAsync<NotFoundException>();
+        await Should.ThrowAsync<NotFoundException>(() => SendAsync(command));
     }
 
     [Test]
@@ -42,10 +42,10 @@ public class UpdateTodoItemTests : BaseTestFixture
 
         var item = await FindAsync<TodoItem>(itemId);
 
-        item.Should().NotBeNull();
-        item!.Title.Should().Be(command.Title);
-        item.LastModifiedBy.Should().NotBeNull();
-        item.LastModifiedBy.Should().Be(userId);
-        item.LastModified.Should().BeCloseTo(DateTime.Now, TimeSpan.FromMilliseconds(10000));
+        item.ShouldNotBeNull();
+        item!.Title.ShouldBe(command.Title);
+        item.LastModifiedBy.ShouldNotBeNull();
+        item.LastModifiedBy.ShouldBe(userId);
+        item.LastModified.ShouldBe(DateTime.Now, TimeSpan.FromMilliseconds(10000));
     }
 }

--- a/tests/Application.FunctionalTests/TodoLists/Commands/CreateTodoListTests.cs
+++ b/tests/Application.FunctionalTests/TodoLists/Commands/CreateTodoListTests.cs
@@ -12,7 +12,7 @@ public class CreateTodoListTests : BaseTestFixture
     public async Task ShouldRequireMinimumFields()
     {
         var command = new CreateTodoListCommand();
-        await FluentActions.Invoking(() => SendAsync(command)).Should().ThrowAsync<ValidationException>();
+        await Should.ThrowAsync<ValidationException>(() => SendAsync(command));
     }
 
     [Test]
@@ -28,8 +28,7 @@ public class CreateTodoListTests : BaseTestFixture
             Title = "Shopping"
         };
 
-        await FluentActions.Invoking(() =>
-            SendAsync(command)).Should().ThrowAsync<ValidationException>();
+        await Should.ThrowAsync<ValidationException>(() => SendAsync(command));
     }
 
     [Test]
@@ -46,9 +45,9 @@ public class CreateTodoListTests : BaseTestFixture
 
         var list = await FindAsync<TodoList>(id);
 
-        list.Should().NotBeNull();
-        list!.Title.Should().Be(command.Title);
-        list.CreatedBy.Should().Be(userId);
-        list.Created.Should().BeCloseTo(DateTime.Now, TimeSpan.FromMilliseconds(10000));
+        list.ShouldNotBeNull();
+        list!.Title.ShouldBe(command.Title);
+        list.CreatedBy.ShouldBe(userId);
+        list.Created.ShouldBe(DateTime.Now, TimeSpan.FromMilliseconds(10000));
     }
 }

--- a/tests/Application.FunctionalTests/TodoLists/Commands/DeleteTodoListTests.cs
+++ b/tests/Application.FunctionalTests/TodoLists/Commands/DeleteTodoListTests.cs
@@ -12,7 +12,7 @@ public class DeleteTodoListTests : BaseTestFixture
     public async Task ShouldRequireValidTodoListId()
     {
         var command = new DeleteTodoListCommand(99);
-        await FluentActions.Invoking(() => SendAsync(command)).Should().ThrowAsync<NotFoundException>();
+        await Should.ThrowAsync<NotFoundException>(() => SendAsync(command));
     }
 
     [Test]
@@ -27,6 +27,6 @@ public class DeleteTodoListTests : BaseTestFixture
 
         var list = await FindAsync<TodoList>(listId);
 
-        list.Should().BeNull();
+        list.ShouldBeNull();
     }
 }

--- a/tests/Application.FunctionalTests/TodoLists/Commands/PurgeTodoListsTests.cs
+++ b/tests/Application.FunctionalTests/TodoLists/Commands/PurgeTodoListsTests.cs
@@ -15,11 +15,13 @@ public class PurgeTodoListsTests : BaseTestFixture
     {
         var command = new PurgeTodoListsCommand();
 
-        command.GetType().Should().BeDecoratedWith<AuthorizeAttribute>();
+        command.GetType().ShouldSatisfyAllConditions(
+            type => type.ShouldBeDecoratedWith<AuthorizeAttribute>()
+        );
 
         var action = () => SendAsync(command);
 
-        await action.Should().ThrowAsync<UnauthorizedAccessException>();
+        await Should.ThrowAsync<UnauthorizedAccessException>(action);
     }
 
     [Test]
@@ -31,7 +33,7 @@ public class PurgeTodoListsTests : BaseTestFixture
 
         var action = () => SendAsync(command);
 
-        await action.Should().ThrowAsync<ForbiddenAccessException>();
+        await Should.ThrowAsync<ForbiddenAccessException>(action);
     }
 
     [Test]
@@ -43,7 +45,8 @@ public class PurgeTodoListsTests : BaseTestFixture
 
         var action = () => SendAsync(command);
 
-        await action.Should().NotThrowAsync<ForbiddenAccessException>();
+        Func<Task> asyncAction = async () => await SendAsync(command);
+        await asyncAction.ShouldNotThrowAsync();
     }
 
     [Test]
@@ -70,6 +73,6 @@ public class PurgeTodoListsTests : BaseTestFixture
 
         var count = await CountAsync<TodoList>();
 
-        count.Should().Be(0);
+        count.ShouldBe(0);
     }
 }

--- a/tests/Application.FunctionalTests/TodoLists/Commands/UpdateTodoListTests.cs
+++ b/tests/Application.FunctionalTests/TodoLists/Commands/UpdateTodoListTests.cs
@@ -13,7 +13,7 @@ public class UpdateTodoListTests : BaseTestFixture
     public async Task ShouldRequireValidTodoListId()
     {
         var command = new UpdateTodoListCommand { Id = 99, Title = "New Title" };
-        await FluentActions.Invoking(() => SendAsync(command)).Should().ThrowAsync<NotFoundException>();
+        await Should.ThrowAsync<NotFoundException>(() => SendAsync(command));
     }
 
     [Test]
@@ -35,10 +35,10 @@ public class UpdateTodoListTests : BaseTestFixture
             Title = "Other List"
         };
 
-        (await FluentActions.Invoking(() =>
-            SendAsync(command))
-                .Should().ThrowAsync<ValidationException>().Where(ex => ex.Errors.ContainsKey("Title")))
-                .And.Errors["Title"].Should().Contain("'Title' must be unique.");
+        var ex = await Should.ThrowAsync<ValidationException>(() => SendAsync(command));
+
+        ex.Errors.ShouldContainKey("Title");
+        ex.Errors["Title"].ShouldContain("'Title' must be unique.");
     }
 
     [Test]
@@ -61,10 +61,10 @@ public class UpdateTodoListTests : BaseTestFixture
 
         var list = await FindAsync<TodoList>(listId);
 
-        list.Should().NotBeNull();
-        list!.Title.Should().Be(command.Title);
-        list.LastModifiedBy.Should().NotBeNull();
-        list.LastModifiedBy.Should().Be(userId);
-        list.LastModified.Should().BeCloseTo(DateTime.Now, TimeSpan.FromMilliseconds(10000));
+        list.ShouldNotBeNull();
+        list!.Title.ShouldBe(command.Title);
+        list.LastModifiedBy.ShouldNotBeNull();
+        list.LastModifiedBy.ShouldBe(userId);
+        list.LastModified.ShouldBe(DateTime.Now, TimeSpan.FromMilliseconds(10000));
     }
 }

--- a/tests/Application.FunctionalTests/TodoLists/Queries/GetTodosTests.cs
+++ b/tests/Application.FunctionalTests/TodoLists/Queries/GetTodosTests.cs
@@ -17,7 +17,7 @@ public class GetTodosTests : BaseTestFixture
 
         var result = await SendAsync(query);
 
-        result.PriorityLevels.Should().NotBeEmpty();
+        result.PriorityLevels.ShouldNotBeEmpty();
     }
 
     [Test]
@@ -30,23 +30,23 @@ public class GetTodosTests : BaseTestFixture
             Title = "Shopping",
             Colour = Colour.Blue,
             Items =
-                    {
-                        new TodoItem { Title = "Apples", Done = true },
-                        new TodoItem { Title = "Milk", Done = true },
-                        new TodoItem { Title = "Bread", Done = true },
-                        new TodoItem { Title = "Toilet paper" },
-                        new TodoItem { Title = "Pasta" },
-                        new TodoItem { Title = "Tissues" },
-                        new TodoItem { Title = "Tuna" }
-                    }
+                {
+                    new TodoItem { Title = "Apples", Done = true },
+                    new TodoItem { Title = "Milk", Done = true },
+                    new TodoItem { Title = "Bread", Done = true },
+                    new TodoItem { Title = "Toilet paper" },
+                    new TodoItem { Title = "Pasta" },
+                    new TodoItem { Title = "Tissues" },
+                    new TodoItem { Title = "Tuna" }
+                }
         });
 
         var query = new GetTodosQuery();
 
         var result = await SendAsync(query);
 
-        result.Lists.Should().HaveCount(1);
-        result.Lists.First().Items.Should().HaveCount(7);
+        result.Lists.Count.ShouldBe(1);
+        result.Lists.First().Items.Count.ShouldBe(7);
     }
 
     [Test]
@@ -55,7 +55,7 @@ public class GetTodosTests : BaseTestFixture
         var query = new GetTodosQuery();
 
         var action = () => SendAsync(query);
-        
-        await action.Should().ThrowAsync<UnauthorizedAccessException>();
+
+        await Should.ThrowAsync<UnauthorizedAccessException>(action);
     }
 }

--- a/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -18,8 +18,8 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Moq" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Application.UnitTests/Common/Exceptions/ValidationExceptionTests.cs
+++ b/tests/Application.UnitTests/Common/Exceptions/ValidationExceptionTests.cs
@@ -1,7 +1,7 @@
 ﻿using CleanArchitecture.Application.Common.Exceptions;
-using FluentAssertions;
 using FluentValidation.Results;
 using NUnit.Framework;
+using Shouldly;
 
 namespace CleanArchitecture.Application.UnitTests.Common.Exceptions;
 
@@ -12,7 +12,7 @@ public class ValidationExceptionTests
     {
         var actual = new ValidationException().Errors;
 
-        actual.Keys.Should().BeEquivalentTo(Array.Empty<string>());
+        actual.Keys.ShouldBeEmpty();
     }
 
     [Test]
@@ -25,8 +25,8 @@ public class ValidationExceptionTests
 
         var actual = new ValidationException(failures).Errors;
 
-        actual.Keys.Should().BeEquivalentTo(new string[] { "Age" });
-        actual["Age"].Should().BeEquivalentTo(new string[] { "must be over 18" });
+        actual.Keys.ShouldBe(new string[] { "Age" });
+        actual["Age"].ShouldBe(new string[] { "must be over 18" });
     }
 
     [Test]
@@ -44,20 +44,20 @@ public class ValidationExceptionTests
 
         var actual = new ValidationException(failures).Errors;
 
-        actual.Keys.Should().BeEquivalentTo(new string[] { "Password", "Age" });
+        actual.Keys.ShouldBe(new string[] { "Password", "Age" }, ignoreOrder: true);
 
-        actual["Age"].Should().BeEquivalentTo(new string[]
+        actual["Age"].ShouldBe(new string[]
         {
                 "must be 25 or younger",
                 "must be 18 or older",
-        });
+        }, ignoreOrder: true);
 
-        actual["Password"].Should().BeEquivalentTo(new string[]
+        actual["Password"].ShouldBe(new string[]
         {
                 "must contain lower case letter",
                 "must contain upper case letter",
                 "must contain at least 8 characters",
                 "must contain a digit",
-        });
+        }, ignoreOrder: true);
     }
 }

--- a/tests/Domain.UnitTests/Domain.UnitTests.csproj
+++ b/tests/Domain.UnitTests/Domain.UnitTests.csproj
@@ -17,7 +17,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Domain.UnitTests/ValueObjects/ColourTests.cs
+++ b/tests/Domain.UnitTests/ValueObjects/ColourTests.cs
@@ -1,7 +1,7 @@
 ﻿using CleanArchitecture.Domain.Exceptions;
 using CleanArchitecture.Domain.ValueObjects;
-using FluentAssertions;
 using NUnit.Framework;
+using Shouldly;
 
 namespace CleanArchitecture.Domain.UnitTests.ValueObjects;
 
@@ -14,7 +14,7 @@ public class ColourTests
 
         var colour = Colour.From(code);
 
-        colour.Code.Should().Be(code);
+        colour.Code.ShouldBe(code);
     }
 
     [Test]
@@ -22,7 +22,7 @@ public class ColourTests
     {
         var colour = Colour.White;
 
-        colour.ToString().Should().Be(colour.Code);
+        colour.ToString().ShouldBe(colour.Code);
     }
 
     [Test]
@@ -30,7 +30,7 @@ public class ColourTests
     {
         string code = Colour.White;
 
-        code.Should().Be("#FFFFFF");
+        code.ShouldBe("#FFFFFF");
     }
 
     [Test]
@@ -38,13 +38,12 @@ public class ColourTests
     {
         var colour = (Colour)"#FFFFFF";
 
-        colour.Should().Be(Colour.White);
+        colour.ShouldBe(Colour.White);
     }
 
     [Test]
     public void ShouldThrowUnsupportedColourExceptionGivenNotSupportedColourCode()
     {
-        FluentActions.Invoking(() => Colour.From("##FF33CC"))
-            .Should().Throw<UnsupportedColourException>();
+        Should.Throw<UnsupportedColourException>(() => Colour.From("##FF33CC"));
     }
 }

--- a/tests/Web.AcceptanceTests/GlobalUsings.cs
+++ b/tests/Web.AcceptanceTests/GlobalUsings.cs
@@ -1,5 +1,5 @@
 ﻿global using CleanArchitecture.Web.AcceptanceTests.Pages;
 global using BoDi;
-global using FluentAssertions;
+global using Shouldly;
 global using Microsoft.Playwright;
 global using TechTalk.SpecFlow;

--- a/tests/Web.AcceptanceTests/StepDefinitions/LoginStepDefinitions.cs
+++ b/tests/Web.AcceptanceTests/StepDefinitions/LoginStepDefinitions.cs
@@ -52,8 +52,8 @@ public sealed class LoginStepDefinitions
     {
         var profileLinkText = await _loginPage.ProfileLinkText();
 
-        profileLinkText.Should().NotBeNull();
-        profileLinkText.Should().Be("Account");
+        profileLinkText.ShouldNotBeNull();
+        profileLinkText.ShouldBe("Account");
     }
 
     [When("the user logs in with invalid credentials")]
@@ -69,7 +69,7 @@ public sealed class LoginStepDefinitions
     {
         var errorVisible = await _loginPage.InvalidLoginAttemptMessageVisible();
 
-        errorVisible.Should().BeTrue();
+        errorVisible.ShouldBeTrue();
     }
 
     [AfterFeature]

--- a/tests/Web.AcceptanceTests/Web.AcceptanceTests.csproj
+++ b/tests/Web.AcceptanceTests/Web.AcceptanceTests.csproj
@@ -20,11 +20,11 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Microsoft.Playwright" />
+        <PackageReference Include="Shouldly" />
         <PackageReference Include="SpecFlow.Plus.LivingDocPlugin" />
         <PackageReference Include="SpecFlow.NUnit" />
         <PackageReference Include="nunit" />
         <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="FluentAssertions" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR removes AutoMapper from the application and replaces all usages with manual mapping functions.

### 🚨 Why?
AutoMapper has recently adopted a commercial license for production use. To avoid potential licensing issues and to keep the project open and dependency-light, this change removes AutoMapper entirely.

### ✅ Changes:
- Removed AutoMapper library and DI configuration
- Replaced `ProjectTo<T>()`, `.Map()` calls, and `Profile` classes with explicit mapping functions
- Added static mappers for:
  - `TodoItemBriefDto`
  - `TodoItemDto`
  - `TodoListDto`
  - `LookupDto`
- Updated query handlers and mapping extensions to support `Func<TSource, TDestination>`
- Simplified the mapping logic, making it more transparent and maintainable

### 🧩 Dependency:
This PR **depends on** [#1320](https://github.com/jasontaylordev/CleanArchitecture/pull/1320), as it introduces the `Shouldly` library used in tests.

### 📚 Housekeeping:
- Removed `AutoMapper` from the list of dependencies in the README

🔒 **Closes**: [#1206](https://github.com/jasontaylordev/CleanArchitecture/issues/1206)
