### PR TITLE
Refactor endpoint mapping to use RouteGroupBuilder

### DIFF
--- a/src/Web/Endpoints/TodoItems.cs
+++ b/src/Web/Endpoints/TodoItems.cs
@@ -10,15 +10,13 @@ namespace CleanArchitecture.Web.Endpoints;
 
 public class TodoItems : EndpointGroupBase
 {
-    public override void Map(WebApplication app)
+    public override void Map(RouteGroupBuilder groupBuilder)
     {
-        app.MapGroup(this)
-            .RequireAuthorization()
-            .MapGet(GetTodoItemsWithPagination)
-            .MapPost(CreateTodoItem)
-            .MapPut(UpdateTodoItem, "{id}")
-            .MapPut(UpdateTodoItemDetail, "UpdateDetail/{id}")
-            .MapDelete(DeleteTodoItem, "{id}");
+        groupBuilder.MapGet(GetTodoItemsWithPagination).RequireAuthorization();
+        groupBuilder.MapPost(CreateTodoItem).RequireAuthorization();
+        groupBuilder.MapPut(UpdateTodoItem, "{id}").RequireAuthorization();
+        groupBuilder.MapPut(UpdateTodoItemDetail, "UpdateDetail/{id}").RequireAuthorization();
+        groupBuilder.MapDelete(DeleteTodoItem, "{id}").RequireAuthorization();
     }
 
     public async Task<Ok<PaginatedList<TodoItemBriefDto>>> GetTodoItemsWithPagination(ISender sender, [AsParameters] GetTodoItemsWithPaginationQuery query)
@@ -47,9 +45,9 @@ public class TodoItems : EndpointGroupBase
     public async Task<Results<NoContent, BadRequest>> UpdateTodoItemDetail(ISender sender, int id, UpdateTodoItemDetailCommand command)
     {
         if (id != command.Id) return TypedResults.BadRequest();
-        
+
         await sender.Send(command);
-        
+
         return TypedResults.NoContent();
     }
 

--- a/src/Web/Endpoints/TodoLists.cs
+++ b/src/Web/Endpoints/TodoLists.cs
@@ -8,14 +8,12 @@ namespace CleanArchitecture.Web.Endpoints;
 
 public class TodoLists : EndpointGroupBase
 {
-    public override void Map(WebApplication app)
+    public override void Map(RouteGroupBuilder groupBuilder)
     {
-        app.MapGroup(this)
-            .RequireAuthorization()
-            .MapGet(GetTodoLists)
-            .MapPost(CreateTodoList)
-            .MapPut(UpdateTodoList, "{id}")
-            .MapDelete(DeleteTodoList, "{id}");
+        groupBuilder.MapGet(GetTodoLists).RequireAuthorization();
+        groupBuilder.MapPost(CreateTodoList).RequireAuthorization();
+        groupBuilder.MapPut(UpdateTodoList, "{id}").RequireAuthorization();
+        groupBuilder.MapDelete(DeleteTodoList, "{id}").RequireAuthorization();
     }
 
     public async Task<Ok<TodosVm>> GetTodoLists(ISender sender)
@@ -35,7 +33,7 @@ public class TodoLists : EndpointGroupBase
     public async Task<Results<NoContent, BadRequest>> UpdateTodoList(ISender sender, int id, UpdateTodoListCommand command)
     {
         if (id != command.Id) return TypedResults.BadRequest();
-        
+
         await sender.Send(command);
 
         return TypedResults.NoContent();

--- a/src/Web/Endpoints/WeatherForecasts.cs
+++ b/src/Web/Endpoints/WeatherForecasts.cs
@@ -5,17 +5,18 @@ namespace CleanArchitecture.Web.Endpoints;
 
 public class WeatherForecasts : EndpointGroupBase
 {
-    public override void Map(WebApplication app)
+    public override void Map(RouteGroupBuilder groupBuilder)
     {
-        app.MapGroup(this)
-            .RequireAuthorization()
-            .MapGet(GetWeatherForecasts);
+        groupBuilder.RequireAuthorization();
+
+        groupBuilder.MapGet(GetWeatherForecasts);
     }
 
     public async Task<Ok<IEnumerable<WeatherForecast>>> GetWeatherForecasts(ISender sender)
     {
         var forecasts = await sender.Send(new GetWeatherForecastsQuery());
-        
+
         return TypedResults.Ok(forecasts);
     }
+
 }

--- a/src/Web/Infrastructure/EndpointGroupBase.cs
+++ b/src/Web/Infrastructure/EndpointGroupBase.cs
@@ -2,5 +2,6 @@
 
 public abstract class EndpointGroupBase
 {
-    public abstract void Map(WebApplication app);
+    public virtual string? GroupName { get; }
+    public abstract void Map(RouteGroupBuilder groupBuilder);
 }

--- a/src/Web/Infrastructure/IEndpointRouteBuilderExtensions.cs
+++ b/src/Web/Infrastructure/IEndpointRouteBuilderExtensions.cs
@@ -2,45 +2,37 @@
 
 namespace CleanArchitecture.Web.Infrastructure;
 
-public static class IEndpointRouteBuilderExtensions
+public static class EndpointRouteBuilderExtensions
 {
-    public static IEndpointRouteBuilder MapGet(this IEndpointRouteBuilder builder, Delegate handler, [StringSyntax("Route")] string pattern = "")
+    public static RouteHandlerBuilder MapGet(this IEndpointRouteBuilder builder, Delegate handler, [StringSyntax("Route")] string pattern = "")
     {
         Guard.Against.AnonymousMethod(handler);
 
-        builder.MapGet(pattern, handler)
-            .WithName(handler.Method.Name);
-
-        return builder;
+        return builder.MapGet(pattern, handler)
+              .WithName(handler.Method.Name);
     }
 
-    public static IEndpointRouteBuilder MapPost(this IEndpointRouteBuilder builder, Delegate handler, [StringSyntax("Route")] string pattern = "")
+    public static RouteHandlerBuilder MapPost(this IEndpointRouteBuilder builder, Delegate handler, [StringSyntax("Route")] string pattern = "")
     {
         Guard.Against.AnonymousMethod(handler);
 
-        builder.MapPost(pattern, handler)
+        return builder.MapPost(pattern, handler)
             .WithName(handler.Method.Name);
-
-        return builder;
     }
 
-    public static IEndpointRouteBuilder MapPut(this IEndpointRouteBuilder builder, Delegate handler, [StringSyntax("Route")] string pattern)
+    public static RouteHandlerBuilder MapPut(this IEndpointRouteBuilder builder, Delegate handler, [StringSyntax("Route")] string pattern)
     {
         Guard.Against.AnonymousMethod(handler);
 
-        builder.MapPut(pattern, handler)
+        return builder.MapPut(pattern, handler)
             .WithName(handler.Method.Name);
-
-        return builder;
     }
 
-    public static IEndpointRouteBuilder MapDelete(this IEndpointRouteBuilder builder, Delegate handler, [StringSyntax("Route")] string pattern)
+    public static RouteHandlerBuilder MapDelete(this IEndpointRouteBuilder builder, Delegate handler, [StringSyntax("Route")] string pattern)
     {
         Guard.Against.AnonymousMethod(handler);
 
-        builder.MapDelete(pattern, handler)
+        return builder.MapDelete(pattern, handler)
             .WithName(handler.Method.Name);
-
-        return builder;
     }
 }

--- a/src/Web/Infrastructure/WebApplicationExtensions.cs
+++ b/src/Web/Infrastructure/WebApplicationExtensions.cs
@@ -4,9 +4,9 @@ namespace CleanArchitecture.Web.Infrastructure;
 
 public static class WebApplicationExtensions
 {
-    public static RouteGroupBuilder MapGroup(this WebApplication app, EndpointGroupBase group)
+    private static RouteGroupBuilder MapGroup(this WebApplication app, EndpointGroupBase group)
     {
-        var groupName = group.GetType().Name;
+        var groupName = group.GroupName ?? group.GetType().Name;
 
         return app
             .MapGroup($"/api/{groupName}")
@@ -27,7 +27,7 @@ public static class WebApplicationExtensions
         {
             if (Activator.CreateInstance(type) is EndpointGroupBase instance)
             {
-                instance.Map(app);
+                instance.Map(app.MapGroup(instance));
             }
         }
 


### PR DESCRIPTION
Hi,  
I updated the endpoint mapping to use RouteGroupBuilder instead of WebApplication.  
This lets us organize routes better and apply settings more precisely—for example, requiring authorization on just one method instead of the whole group.  
I also added a way to name these groups more clearly instead of relying on class names.  

Please review when you get a chance and let me know if you have any feedback.  
Thanks!
