### PR TITLE
Make BaseEntity generic & added default 'int' key

### DIFF
--- a/src/Domain/Common/BaseEntity.cs
+++ b/src/Domain/Common/BaseEntity.cs
@@ -1,12 +1,17 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace CleanArchitecture.Domain.Common;
 
-public abstract class BaseEntity
+// Non-generic version defaults to int
+public abstract class BaseEntity : BaseEntity<int>
 {
-    // This can easily be modified to be BaseEntity<T> and public T Id to support different key types.
-    // Using non-generic integer types for simplicity
-    public int Id { get; set; }
+}
+
+public abstract class BaseEntity<TKey>
+{
+    [Key]
+    public TKey? Id { get; set; }
 
     private readonly List<BaseEvent> _domainEvents = new();
 


### PR DESCRIPTION
**Changes**
- Added generic BaseEntity<TKey> class with nullable Id property of type TKey.
- Updated non-generic BaseEntity class to inherit from BaseEntity<int> as a default implementation.

**Explanation**
This change introduces a generic version of the BaseEntity class to support different types of primary keys. The existing non-generic BaseEntity now inherits from BaseEntity<int>, making int the default key type to maintain backward compatibility.
