### PR TITLE
Fix: Avoid shared ValidationContext to ensure thread safety during parallel validation

### DIFF
--- a/src/Application/Common/Behaviours/ValidationBehaviour.cs
+++ b/src/Application/Common/Behaviours/ValidationBehaviour.cs
@@ -16,20 +16,19 @@ public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TReque
     {
         if (_validators.Any())
         {
-            var context = new ValidationContext<TRequest>(request);
-
             var validationResults = await Task.WhenAll(
                 _validators.Select(v =>
-                    v.ValidateAsync(context, cancellationToken)));
+                    v.ValidateAsync(new ValidationContext<TRequest>(request), cancellationToken)));
 
             var failures = validationResults
                 .Where(r => r.Errors.Any())
                 .SelectMany(r => r.Errors)
                 .ToList();
 
-            if (failures.Any())
+            if (failures.Count != 0)
                 throw new ValidationException(failures);
         }
+
         return await next();
     }
 }


### PR DESCRIPTION
This change ensures a new `ValidationContext` is created for each validator to avoid issues when running validations in parallel.

Sharing the same context across multiple validators can cause unexpected behavior, so this update makes validation more reliable and thread-safe.