### PR TITLE
Fix for error 'Users' does not implement inherited abstract member 

### DIFF
--- a/src/Web/Endpoints/Users.cs
+++ b/src/Web/Endpoints/Users.cs
@@ -5,10 +5,9 @@ namespace CleanArchitecture.Web.Endpoints;
 
 public class Users : EndpointGroupBase
 {
-    public override void Map(WebApplication app)
+    public override void Map(RouteGroupBuilder groupBuilder)
     {
-        app.MapGroup(this)
-            .MapIdentityApi<ApplicationUser>();
+        groupBuilder.MapIdentityApi<ApplicationUser>();
     }
 }
 #endif


### PR DESCRIPTION
Fix for issue #1366: 'Users' does not implement inherited abstract member 'EndpointGroupBase.Map(RouteGroupBuilder)'