### PR TITLE
fix: 'Users' does not implement inherited abstract member 'EndpointGr…

### DIFF
--- a/src/Web/Endpoints/Users.cs
+++ b/src/Web/Endpoints/Users.cs
@@ -5,10 +5,9 @@ namespace CleanArchitecture.Web.Endpoints;
 
 public class Users : EndpointGroupBase
 {
-    public override void Map(WebApplication app)
+    public override void Map(RouteGroupBuilder groupBuilder)
     {
-        app.MapGroup(this)
-            .MapIdentityApi<ApplicationUser>();
+        groupBuilder.MapIdentityApi<ApplicationUser>();
     }
 }
 #endif


### PR DESCRIPTION
When create new API App only using command below
```bash
dotnet new ca-sln -cf None -o <dbname> -ua -db postgresql
```

Run app in Visual Studio got error
```
'Users' does not implement inherited abstract member 'EndpointGroupBase.Map(RouteGroupBuilder)'
'Users.Map(WebApplication)': no suitable method found to override
Argument 2: cannot convert from 'ERP.LMS.Web.Endpoints.Users' to 'string'
```
