### PR TITLE
Escape DEBUG directive in LoginStepDefinitions (Fixes #1373)

### DIFF
--- a/tests/Web.AcceptanceTests/StepDefinitions/LoginStepDefinitions.cs
+++ b/tests/Web.AcceptanceTests/StepDefinitions/LoginStepDefinitions.cs
@@ -17,10 +17,12 @@ public sealed class LoginStepDefinitions
 
         var options = new BrowserTypeLaunchOptions();
 
+        //-:cnd:noEmit
 #if DEBUG
         options.Headless = false;
         options.SlowMo = 500;
 #endif
+        //+:cnd:noEmit
 
         var browser = await playwright.Chromium.LaunchAsync(options);
 


### PR DESCRIPTION
This PR fixes Issue #1373 by wrapping the Debug-only Playwright launch options
in LoginStepDefinitions.cs with templating ignore comments (`//-:cnd:noEmit` 
and `//+:cnd:noEmit`) so they are preserved when generating a new solution
from the template.

The change ensures that the `#if DEBUG` block remains in generated projects,
allowing developers to see Playwright run in headful mode during debugging.
