### PR TITLE
Remove CodeQL from PR checks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,14 +9,6 @@ on:
       - LICENSE
       - README.md
 
-  pull_request:
-    branches: [ main ]
-    paths-ignore:
-      - .gitignore
-      - CODE_OF_CONDUCT.md
-      - LICENSE
-      - README.md
-
   schedule:
     - cron: '00 0 * * 1'
 


### PR DESCRIPTION
Removes the CodeQL workflow trigger on pull requests. CodeQL still runs on push to main and on the weekly schedule.