### PR TITLE
Fix NSwag build error when using ArtifactsPath

### DIFF
--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -68,7 +68,7 @@
   </PropertyGroup>
 
   <Target Name="NSwag" AfterTargets="PostBuildEvent" Condition=" '$(Configuration)' == 'Debug' And '$(SkipNSwag)' != 'True' ">
-    <Exec ConsoleToMSBuild="true" ContinueOnError="true" WorkingDirectory="$(ProjectDir)" EnvironmentVariables="ASPNETCORE_ENVIRONMENT=Development" Command="$(NSwagExe_Net100) run config.nswag /variables:Configuration=$(Configuration)">
+    <Exec ConsoleToMSBuild="true" ContinueOnError="true" WorkingDirectory="$(ProjectDir)" EnvironmentVariables="ASPNETCORE_ENVIRONMENT=Development" Command="$(NSwagExe_Net100) run config.nswag /variables:Configuration=$(Configuration),MSBuildProjectExtensionsPath=$(MSBuildProjectExtensionsPath)">
       <Output TaskParameter="ExitCode" PropertyName="NSwagExitCode" />
       <Output TaskParameter="ConsoleOutput" PropertyName="NSwagOutput" />
     </Exec>

--- a/src/Web/config.nswag
+++ b/src/Web/config.nswag
@@ -5,7 +5,7 @@
     "aspNetCoreToOpenApi": {
       "project": "Web.csproj",
       "documentName": "v1",
-      "msBuildProjectExtensionsPath": null,
+      "msBuildProjectExtensionsPath": "$(MSBuildProjectExtensionsPath)",
       "configuration": null,
       "runtime": null,
       "targetFramework": null,


### PR DESCRIPTION
Fixes #1379
Fixes #1424

## Problem

When `ArtifactsPath` is set in `Directory.Build.props`, the intermediate output directory moves from the default `src/Web/obj/` to `artifacts/obj/Web/`. When the NSwag AfterBuild target runs, it spawns a separate MSBuild process to read project metadata, but that process isn't aware of the custom path and fails to find the `__GetNSwagProjectMetadata` target injected by `NSwag.MSBuild`.

This produces the error:

```
error MSB4057: The target "__GetNSwagProjectMetadata" does not exist in the project.
System.InvalidOperationException: Unable to retrieve project metadata.
```

## Fix

Pass `MSBuildProjectExtensionsPath` from the MSBuild context as a variable into `config.nswag`, so NSwag can locate the correct intermediate output directory regardless of how `ArtifactsPath` is configured.