### PR TITLE
Fix Domain README: event handlers belong in Application

### DIFF
--- a/src/Domain/README.md
+++ b/src/Domain/README.md
@@ -6,7 +6,7 @@ The **Domain** project contains the core business logic of the application.
 - Entities  
 - Value Objects  
 - Aggregates  
-- Domain Events and Event Handlers  
+- Domain Events
 - Business rules and invariants  
 
 ## Dependencies


### PR DESCRIPTION
Event handlers live in the Application layer, not Domain. Domain only owns the event definitions themselves.