### PR TITLE
Fix missing closing code fence in infra README

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -18,3 +18,4 @@ This folder contains infrastructure-as-code and deployment templates used with t
 ```bash
 azd auth login
 azd up
+```


### PR DESCRIPTION
The azd deployment code block was missing its closing fence.