### PR TITLE
Fix NSwag failure when project path contains spaces

### DIFF
--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -68,7 +68,7 @@
   </PropertyGroup>
 
   <Target Name="NSwag" AfterTargets="PostBuildEvent" Condition=" '$(Configuration)' == 'Debug' And '$(SkipNSwag)' != 'True' ">
-    <Exec ConsoleToMSBuild="true" ContinueOnError="true" WorkingDirectory="$(ProjectDir)" EnvironmentVariables="ASPNETCORE_ENVIRONMENT=Development" Command="$(NSwagExe_Net100) run config.nswag /variables:Configuration=$(Configuration),MSBuildProjectExtensionsPath=$(MSBuildProjectExtensionsPath)">
+    <Exec ConsoleToMSBuild="true" ContinueOnError="true" WorkingDirectory="$(ProjectDir)" EnvironmentVariables="ASPNETCORE_ENVIRONMENT=Development" Command="$(NSwagExe_Net100) run config.nswag /variables:Configuration=$(Configuration),MSBuildProjectExtensionsPath=&quot;$(ArtifactsPath)\obj\Web&quot;">
       <Output TaskParameter="ExitCode" PropertyName="NSwagExitCode" />
       <Output TaskParameter="ConsoleOutput" PropertyName="NSwagOutput" />
     </Exec>


### PR DESCRIPTION
When the project path contains spaces, the MSBuildProjectExtensionsPath value was being split by cmd.exe, causing NSwag to fail with an unrecognised arguments error.

Fixed by constructing the path directly from `$(ArtifactsPath)` and quoting it with `&quot;` so cmd.exe treats it as a single token.