### PR TITLE
Bump Npgsql.EntityFrameworkCore.PostgreSQL to 10.0.0 RTM

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,7 +69,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.13.0" />
     <!--#endif-->
     <!--#if (UsePostgreSQL)-->
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0-rc.2" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.8.1" />
     <!--#endif-->
     <!--#if (UseSqlite)-->


### PR DESCRIPTION
Fixes 16 NU1608 build warnings caused by the rc.2 package requiring a specific pre-release version of EF Core that no longer matches the resolved 10.0.0 RTM version.