### PR TITLE
Fix HasPreviousPage returning true for out-of-range page numbers

### DIFF
--- a/src/Application/Common/Models/PaginatedList.cs
+++ b/src/Application/Common/Models/PaginatedList.cs
@@ -15,7 +15,7 @@ public class PaginatedList<T>
         Items = items;
     }
 
-    public bool HasPreviousPage => PageNumber > 1;
+    public bool HasPreviousPage => PageNumber > 1 && PageNumber <= TotalPages + 1;
 
     public bool HasNextPage => PageNumber < TotalPages;
 

--- a/tests/Application.UnitTests/Common/Models/PaginatedListTests.cs
+++ b/tests/Application.UnitTests/Common/Models/PaginatedListTests.cs
@@ -1,0 +1,56 @@
+using CleanArchitecture.Application.Common.Models;
+using NUnit.Framework;
+using Shouldly;
+
+namespace CleanArchitecture.Application.UnitTests.Common.Models;
+
+public class PaginatedListTests
+{
+    [Test]
+    public void HasPreviousPage_ShouldBeFalse_WhenOnFirstPage()
+    {
+        var list = new PaginatedList<int>([], 100, pageNumber: 1, pageSize: 10);
+
+        list.HasPreviousPage.ShouldBeFalse();
+    }
+
+    [Test]
+    public void HasPreviousPage_ShouldBeTrue_WhenOnSecondPage()
+    {
+        var list = new PaginatedList<int>([], 100, pageNumber: 2, pageSize: 10);
+
+        list.HasPreviousPage.ShouldBeTrue();
+    }
+
+    [Test]
+    public void HasPreviousPage_ShouldBeTrue_WhenOnePageBeyondLastPage()
+    {
+        var list = new PaginatedList<int>([], 100, pageNumber: 11, pageSize: 10);
+
+        list.HasPreviousPage.ShouldBeTrue();
+    }
+
+    [Test]
+    public void HasPreviousPage_ShouldBeFalse_WhenTwoPagesOrMoreBeyondLastPage()
+    {
+        var list = new PaginatedList<int>([], 100, pageNumber: 12, pageSize: 10);
+
+        list.HasPreviousPage.ShouldBeFalse();
+    }
+
+    [Test]
+    public void HasNextPage_ShouldBeFalse_WhenOnLastPage()
+    {
+        var list = new PaginatedList<int>([], 100, pageNumber: 10, pageSize: 10);
+
+        list.HasNextPage.ShouldBeFalse();
+    }
+
+    [Test]
+    public void HasNextPage_ShouldBeTrue_WhenNotOnLastPage()
+    {
+        var list = new PaginatedList<int>([], 100, pageNumber: 9, pageSize: 10);
+
+        list.HasNextPage.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
`HasPreviousPage` was returning `true` for any page number greater than 1, including numbers well beyond `TotalPages`. For example, with `TotalPages = 10` and `PageNumber = 12`, the previous page (11) does not exist, so `HasPreviousPage` should be `false`.

The fix adds an upper bound: `PageNumber <= TotalPages + 1`. This allows the one-past-last page to still navigate back to the final valid page, while pages further out of range correctly return `false`.

Closes #1392