### PR TITLE
Rename event handlers to describe their action

### DIFF
--- a/src/Application/TodoItems/EventHandlers/LogTodoItemCompleted.cs
+++ b/src/Application/TodoItems/EventHandlers/LogTodoItemCompleted.cs
@@ -3,11 +3,11 @@ using Microsoft.Extensions.Logging;
 
 namespace CleanArchitecture.Application.TodoItems.EventHandlers;
 
-public class TodoItemCompletedEventHandler : INotificationHandler<TodoItemCompletedEvent>
+public class LogTodoItemCompleted : INotificationHandler<TodoItemCompletedEvent>
 {
-    private readonly ILogger<TodoItemCompletedEventHandler> _logger;
+    private readonly ILogger<LogTodoItemCompleted> _logger;
 
-    public TodoItemCompletedEventHandler(ILogger<TodoItemCompletedEventHandler> logger)
+    public LogTodoItemCompleted(ILogger<LogTodoItemCompleted> logger)
     {
         _logger = logger;
     }

--- a/src/Application/TodoItems/EventHandlers/LogTodoItemCreated.cs
+++ b/src/Application/TodoItems/EventHandlers/LogTodoItemCreated.cs
@@ -3,11 +3,11 @@ using Microsoft.Extensions.Logging;
 
 namespace CleanArchitecture.Application.TodoItems.EventHandlers;
 
-public class TodoItemCreatedEventHandler : INotificationHandler<TodoItemCreatedEvent>
+public class LogTodoItemCreated : INotificationHandler<TodoItemCreatedEvent>
 {
-    private readonly ILogger<TodoItemCreatedEventHandler> _logger;
+    private readonly ILogger<LogTodoItemCreated> _logger;
 
-    public TodoItemCreatedEventHandler(ILogger<TodoItemCreatedEventHandler> logger)
+    public LogTodoItemCreated(ILogger<LogTodoItemCreated> logger)
     {
         _logger = logger;
     }


### PR DESCRIPTION
Names handlers after what they do rather than which event they handle. This makes it natural to add multiple handlers per event without violating SRP, and makes the intent of each handler immediately clear from its name.

- `TodoItemCreatedEventHandler` -> `LogTodoItemCreated`
- `TodoItemCompletedEventHandler` -> `LogTodoItemCompleted`

Closes #1218