### PR TITLE
Add azd pipeline config to deploy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ azd auth login
 azd up
 ```
 
+To set up a CI/CD pipeline (GitHub Actions or Azure DevOps):
+
+```bash
+azd pipeline config
+```
+
 ## Technologies
 
 * [ASP.NET Core 9](https://docs.microsoft.com/en-us/aspnet/core/introduction-to-aspnet-core)


### PR DESCRIPTION
Documents `azd pipeline config` in the Deploy section of the README, which sets up a CI/CD pipeline for GitHub Actions or Azure DevOps automatically.

Closes #1235