### PR TITLE
Fix outdated version numbers and typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ azd pipeline config
 
 ## Technologies
 
-* [ASP.NET Core 9](https://docs.microsoft.com/en-us/aspnet/core/introduction-to-aspnet-core)
-* [Entity Framework Core 9](https://docs.microsoft.com/en-us/ef/core/)
+* [ASP.NET Core 10](https://docs.microsoft.com/en-us/aspnet/core/introduction-to-aspnet-core)
+* [Entity Framework Core 10](https://docs.microsoft.com/en-us/ef/core/)
 * [Angular 18](https://angular.dev/) or [React 18](https://react.dev/)
 * [MediatR](https://github.com/jbogard/MediatR)
 * [AutoMapper](https://automapper.org/)
 * [FluentValidation](https://fluentvalidation.net/)
-* [NUnit](https://nunit.org/), [Shoudly](https://docs.shouldly.org/), [Moq](https://github.com/devlooped/moq) & [Respawn](https://github.com/jbogard/Respawn)
+* [NUnit](https://nunit.org/), [Shouldly](https://docs.shouldly.org/), [Moq](https://github.com/devlooped/moq) & [Respawn](https://github.com/jbogard/Respawn)
 
 ## Versions
 The main branch is now on .NET 10.0. The following previous versions are available:


### PR DESCRIPTION
## Summary
- Update ASP.NET Core and Entity Framework Core version references from 9 to 10
- Fix "Shoudly" typo to "Shouldly"