### PR TITLE
Fix API_BASE_URL not provided in Angular app module

### DIFF
--- a/src/Web/ClientApp/src/app/app.module.ts
+++ b/src/Web/ClientApp/src/app/app.module.ts
@@ -12,8 +12,14 @@ import { HomeComponent } from './home/home.component';
 import { CounterComponent } from './counter/counter.component';
 import { FetchDataComponent } from './fetch-data/fetch-data.component';
 import { TodoComponent } from './todo/todo.component';
+import { API_BASE_URL } from './web-api-client';
 import { AuthorizeInterceptor } from 'src/api-authorization/authorize.interceptor';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+export function getApiBaseUrl(): string {
+  const url = document.getElementsByTagName('base')[0].href;
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
 
 @NgModule({
     declarations: [
@@ -39,6 +45,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
     providers: [
         { provide: APP_ID, useValue: 'ng-cli-universal' },
         { provide: HTTP_INTERCEPTORS, useClass: AuthorizeInterceptor, multi: true },
+        { provide: API_BASE_URL, useFactory: getApiBaseUrl, deps: [] },
         provideHttpClient(withInterceptorsFromDi())
     ]
 })


### PR DESCRIPTION
## Summary
- Registers `API_BASE_URL` as a DI provider in `AppModule`, resolving the base URL from the `<base>` tag href
- Without this, the NSwag-generated client falls back to `""`, causing API calls to resolve from the root path rather than the app's base path
- Fixes #1398

## Test plan
- Run the Angular app hosted under a subfolder (e.g., IIS virtual directory) and verify API calls resolve correctly