### PR TITLE
Refactor the IdentityUser and Domain

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <!--#endif-->
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />

--- a/src/Application/Common/Interfaces/IIdentityService.cs
+++ b/src/Application/Common/Interfaces/IIdentityService.cs
@@ -1,4 +1,5 @@
 ﻿using CleanArchitecture.Application.Common.Models;
+using CleanArchitecture.Domain.Entities;
 
 namespace CleanArchitecture.Application.Common.Interfaces;
 
@@ -13,4 +14,6 @@ public interface IIdentityService
     Task<(Result Result, string UserId)> CreateUserAsync(string userName, string password);
 
     Task<Result> DeleteUserAsync(string userId);
+
+    Task<User?> GetUserByIdAsync(string userId);
 }

--- a/src/Application/Common/Models/UserDto.cs
+++ b/src/Application/Common/Models/UserDto.cs
@@ -1,0 +1,22 @@
+﻿using CleanArchitecture.Domain.Entities;
+
+namespace CleanArchitecture.Application.Common.Models;
+
+public record UserDto
+{
+    public string? Id { get; init; }
+    public string? DisplayName { get; init; }
+    public string? Email { get; init; }
+    public string? PhoneNumber { get; init; }
+    public bool EmailConfirmed { get; init; }
+    public bool PhoneNumberConfirmed { get; init; }
+    public IReadOnlyCollection<string> Roles { get; init; } = [];
+    private class Mapping : Profile
+    {
+        public Mapping()
+        {
+            CreateMap<User, UserDto>()
+                .ForMember(dest => dest.Roles, o => o.MapFrom(src => src.UserRoles.Select(r => r.Role.Name).ToList()));
+        }
+    }
+}

--- a/src/Domain/Common/BaseAuditableEntity.cs
+++ b/src/Domain/Common/BaseAuditableEntity.cs
@@ -1,6 +1,6 @@
 ﻿namespace CleanArchitecture.Domain.Common;
 
-public abstract class BaseAuditableEntity : BaseEntity
+public abstract class BaseAuditableEntity : BaseEntity, IDateAuditable, IUserAuditable
 {
     public DateTimeOffset Created { get; set; }
 

--- a/src/Domain/Common/BaseEntity.cs
+++ b/src/Domain/Common/BaseEntity.cs
@@ -1,30 +1,22 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
+using CleanArchitecture.Domain.Interfaces;
 
 namespace CleanArchitecture.Domain.Common;
 
-public abstract class BaseEntity
+public abstract class BaseEntity : IHasDomainEvents
 {
     // This can easily be modified to be BaseEntity<T> and public T Id to support different key types.
     // Using non-generic integer types for simplicity
     public int Id { get; set; }
 
-    private readonly List<BaseEvent> _domainEvents = new();
+    private readonly List<BaseEvent> _domainEvents = [];
 
     [NotMapped]
     public IReadOnlyCollection<BaseEvent> DomainEvents => _domainEvents.AsReadOnly();
 
-    public void AddDomainEvent(BaseEvent domainEvent)
-    {
-        _domainEvents.Add(domainEvent);
-    }
+    public void AddDomainEvent(BaseEvent domainEvent) => _domainEvents.Add(domainEvent);
 
-    public void RemoveDomainEvent(BaseEvent domainEvent)
-    {
-        _domainEvents.Remove(domainEvent);
-    }
+    public void RemoveDomainEvent(BaseEvent domainEvent) => _domainEvents.Remove(domainEvent);
 
-    public void ClearDomainEvents()
-    {
-        _domainEvents.Clear();
-    }
+    public void ClearDomainEvents() => _domainEvents.Clear();
 }

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" />
   </ItemGroup>
 
 </Project>

--- a/src/Domain/Entities/ApplicationRole.cs
+++ b/src/Domain/Entities/ApplicationRole.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace CleanArchitecture.Domain.Entities;
+
+public class ApplicationRole : IdentityRole
+{
+    public virtual ICollection<UserRole> UserRoles { get; set; } = [];
+    public ApplicationRole() { }
+    public ApplicationRole(string roleName) : base(roleName) { }
+}

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -1,0 +1,34 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.AspNetCore.Identity;
+
+namespace CleanArchitecture.Domain.Entities;
+
+/// <summary>
+/// User identity, where you can define more properties based on the business logic for your application.
+/// You can also add <see cref="IHasDomainEvents"/> to perform the domain events based on the user creation or remove it.
+/// In <see cref="IdentityUser{T}"/> You can change the Id type too, default is string.
+/// </summary>
+public class User : IdentityUser, IHasDomainEvents
+{
+    public string DisplayName { get; private set; } = null!;
+
+    public virtual ICollection<UserRole> UserRoles { get; set; } = [];
+
+    private readonly List<BaseEvent> _domainEvents = [];
+    [NotMapped]
+    public IReadOnlyCollection<BaseEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    public User() { }
+    public User(string displayName, string username)
+    {
+        DisplayName = displayName;
+        UserName = username;
+        Email = username;
+    }
+
+    public void AddDomainEvent(BaseEvent domainEvent) => _domainEvents.Add(domainEvent);
+
+    public void RemoveDomainEvent(BaseEvent domainEvent) => _domainEvents.Remove(domainEvent);
+
+    public void ClearDomainEvents() => _domainEvents.Clear();
+}

--- a/src/Domain/Entities/UserRole.cs
+++ b/src/Domain/Entities/UserRole.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace CleanArchitecture.Domain.Entities;
+
+// https://learn.microsoft.com/en-us/aspnet/core/security/authentication/customize-identity-model?view=aspnetcore-10.0#add-all-navigation-properties
+public class UserRole : IdentityUserRole<string>
+{
+    public virtual User User { get; set; } = null!;
+    public virtual ApplicationRole Role { get; set; } = null!;
+}

--- a/src/Domain/Enums/PriorityLevel.cs
+++ b/src/Domain/Enums/PriorityLevel.cs
@@ -1,5 +1,9 @@
-﻿namespace CleanArchitecture.Domain.Enums;
+﻿using System.Text.Json.Serialization;
 
+namespace CleanArchitecture.Domain.Enums;
+
+// You can add the Serialization https://learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/include-metadata?view=aspnetcore-10.0&tabs=minimal-apis#enum
+//[JsonConverter(typeof(JsonStringEnumConverter<PriorityLevel>))]
 public enum PriorityLevel
 {
     None = 0,

--- a/src/Domain/GlobalUsings.cs
+++ b/src/Domain/GlobalUsings.cs
@@ -4,3 +4,4 @@ global using CleanArchitecture.Domain.Enums;
 global using CleanArchitecture.Domain.Events;
 global using CleanArchitecture.Domain.Exceptions;
 global using CleanArchitecture.Domain.ValueObjects;
+global using CleanArchitecture.Domain.Interfaces;

--- a/src/Domain/Interfaces/IDateAuditable.cs
+++ b/src/Domain/Interfaces/IDateAuditable.cs
@@ -1,0 +1,7 @@
+﻿namespace CleanArchitecture.Domain.Interfaces;
+
+public interface IDateAuditable
+{
+    public DateTimeOffset Created { get; set; }
+    public DateTimeOffset LastModified { get; set; }
+}

--- a/src/Domain/Interfaces/IHasDomainEvents.cs
+++ b/src/Domain/Interfaces/IHasDomainEvents.cs
@@ -1,0 +1,9 @@
+﻿namespace CleanArchitecture.Domain.Interfaces;
+
+public interface IHasDomainEvents
+{
+    IReadOnlyCollection<BaseEvent> DomainEvents { get; }
+    void AddDomainEvent(BaseEvent domainEvent);
+    void RemoveDomainEvent(BaseEvent domainEvent);
+    void ClearDomainEvents();
+}

--- a/src/Domain/Interfaces/IUserAuditable.cs
+++ b/src/Domain/Interfaces/IUserAuditable.cs
@@ -1,0 +1,7 @@
+﻿namespace CleanArchitecture.Domain.Interfaces;
+
+public interface IUserAuditable
+{
+    public string? CreatedBy { get; set; }
+    public string? LastModifiedBy { get; set; }
+}

--- a/src/Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/Data/ApplicationDbContext.cs
@@ -1,13 +1,13 @@
 ﻿using System.Reflection;
 using CleanArchitecture.Application.Common.Interfaces;
 using CleanArchitecture.Domain.Entities;
-using CleanArchitecture.Infrastructure.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace CleanArchitecture.Infrastructure.Data;
 
-public class ApplicationDbContext : IdentityDbContext<ApplicationUser>, IApplicationDbContext
+// https://learn.microsoft.com/en-us/aspnet/core/security/authentication/customize-identity-model?view=aspnetcore-10.0#model-generic-types
+public class ApplicationDbContext : IdentityDbContext<User, ApplicationRole, string>, IApplicationDbContext
 {
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
 

--- a/src/Infrastructure/Data/ApplicationDbContextInitialiser.cs
+++ b/src/Infrastructure/Data/ApplicationDbContextInitialiser.cs
@@ -1,10 +1,11 @@
-﻿using CleanArchitecture.Domain.Constants;
+﻿using System.Reflection;
+using CleanArchitecture.Domain.Constants;
 using CleanArchitecture.Domain.Entities;
-using CleanArchitecture.Infrastructure.Identity;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace CleanArchitecture.Infrastructure.Data;
@@ -27,7 +28,7 @@ public static class InitialiserExtensions
 
         var initialiser = scope.ServiceProvider.GetRequiredService<ApplicationDbContextInitialiser>();
 
-        await initialiser.InitialiseAsync();
+        await initialiser.InitialiseAsync(app.Environment.IsDevelopment());
     }
 }
 
@@ -35,10 +36,10 @@ public class ApplicationDbContextInitialiser
 {
     private readonly ILogger<ApplicationDbContextInitialiser> _logger;
     private readonly ApplicationDbContext _context;
-    private readonly UserManager<ApplicationUser> _userManager;
-    private readonly RoleManager<IdentityRole> _roleManager;
+    private readonly UserManager<User> _userManager;
+    private readonly RoleManager<ApplicationRole> _roleManager;
 
-    public ApplicationDbContextInitialiser(ILogger<ApplicationDbContextInitialiser> logger, ApplicationDbContext context, UserManager<ApplicationUser> userManager, RoleManager<IdentityRole> roleManager)
+    public ApplicationDbContextInitialiser(ILogger<ApplicationDbContextInitialiser> logger, ApplicationDbContext context, UserManager<User> userManager, RoleManager<ApplicationRole> roleManager)
     {
         _logger = logger;
         _context = context;
@@ -46,11 +47,20 @@ public class ApplicationDbContextInitialiser
         _roleManager = roleManager;
     }
 
-    public async Task InitialiseAsync()
+    public async Task InitialiseAsync(bool isDevelopment)
     {
         try
         {
-            await _context.Database.MigrateAsync();
+            // Can add more condition, _context.Database.IsNpgsql or _context.Database.IsSqlServer based on the default database.
+            if (!isDevelopment)
+            {
+                await _context.Database.MigrateAsync();
+            }
+            else if (isDevelopment)
+            {
+                await _context.Database.EnsureDeletedAsync();
+                await _context.Database.EnsureCreatedAsync();
+            }
         }
         catch (Exception ex)
         {
@@ -74,25 +84,8 @@ public class ApplicationDbContextInitialiser
 
     public async Task TrySeedAsync()
     {
-        // Default roles
-        var administratorRole = new IdentityRole(Roles.Administrator);
-
-        if (_roleManager.Roles.All(r => r.Name != administratorRole.Name))
-        {
-            await _roleManager.CreateAsync(administratorRole);
-        }
-
-        // Default users
-        var administrator = new ApplicationUser { UserName = "administrator@localhost", Email = "administrator@localhost" };
-
-        if (_userManager.Users.All(u => u.UserName != administrator.UserName))
-        {
-            await _userManager.CreateAsync(administrator, "Administrator1!");
-            if (!string.IsNullOrWhiteSpace(administratorRole.Name))
-            {
-                await _userManager.AddToRolesAsync(administrator, new [] { administratorRole.Name });
-            }
-        }
+        await SeedRolesAsync();
+        await SeedAdminAsync();
 
         // Default data
         // Seed, if necessary
@@ -111,6 +104,67 @@ public class ApplicationDbContextInitialiser
             });
 
             await _context.SaveChangesAsync();
+        }
+    }
+
+    // =============Helpers=============
+    async Task SeedRolesAsync()
+    {
+        try
+        {
+            // You can add N of Roles inside this Roles Constant.
+            var roles = typeof(Roles)
+                .GetFields(BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Static)
+                .Where(t => t.IsLiteral && !t.IsInitOnly)
+                .Select(property => property.GetRawConstantValue()?.ToString())
+                .Select(role => new ApplicationRole(role!))
+                .ToList();
+
+            foreach (var role in roles)
+            {
+                if (!await _roleManager.RoleExistsAsync(role.Name!))
+                {
+                    await _roleManager.CreateAsync(role);
+                    _logger.LogInformation("Role {roleName} added", role.Name);
+                }
+                else
+                {
+                    _logger.LogInformation("Skipping {roleName}, it is already added.", role.Name);
+                }
+            }
+            _logger.LogInformation("Roles {roles} are successfully added.", string.Join(';', roles.Select(r => r.Name)));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occured during seeding roles.");
+            throw;
+        }
+    }
+
+    async Task SeedAdminAsync()
+    {
+        try
+        {
+            var user = new User("Admin user", "administrator@localhost");
+
+            if (_userManager.Users.All(x => x.UserName != user.UserName))
+            {
+                await _userManager.CreateAsync(user, "Administrator1!");
+                await _userManager.AddToRoleAsync(user, Roles.Administrator);
+
+                _logger.LogInformation("Admin user added.");
+            }
+            else
+            {
+                _logger.LogInformation("Skipping {displayName}, {username} already existed.", user.DisplayName, user.Email);
+            }
+
+            _logger.LogInformation("Seeding admin user completed.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogInformation(ex, "Failed to seeding admin user.");
+            throw;
         }
     }
 }

--- a/src/Infrastructure/Data/Configurations/UserRoleConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/UserRoleConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using CleanArchitecture.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CleanArchitecture.Infrastructure.Data.Configurations;
+
+internal sealed class UserRoleConfiguration : IEntityTypeConfiguration<UserRole>
+{
+    public void Configure(EntityTypeBuilder<UserRole> builder)
+    {
+        builder.HasOne(x => x.User)
+            .WithMany(x => x.UserRoles)
+            .HasForeignKey(x => x.UserId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Cascade); // You can change it based on your requirement.
+
+        builder.HasOne(x => x.Role)
+            .WithMany(x => x.UserRoles)
+            .HasForeignKey(x => x.RoleId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.NoAction); // You can change it based on your requirement.
+    }
+}

--- a/src/Infrastructure/Data/Interceptors/AuditableEntityInterceptor.cs
+++ b/src/Infrastructure/Data/Interceptors/AuditableEntityInterceptor.cs
@@ -1,5 +1,5 @@
 ﻿using CleanArchitecture.Application.Common.Interfaces;
-using CleanArchitecture.Domain.Common;
+using CleanArchitecture.Domain.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -21,23 +21,43 @@ public class AuditableEntityInterceptor : SaveChangesInterceptor
 
     public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
     {
-        UpdateEntities(eventData.Context);
+        UpdateDatetimeAudit(eventData.Context);
+        UpdateUserAudit(eventData.Context);
 
         return base.SavingChanges(eventData, result);
     }
 
     public override ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
     {
-        UpdateEntities(eventData.Context);
+        UpdateDatetimeAudit(eventData.Context);
+        UpdateUserAudit(eventData.Context);
 
         return base.SavingChangesAsync(eventData, result, cancellationToken);
     }
 
-    public void UpdateEntities(DbContext? context)
+    public void UpdateDatetimeAudit(DbContext? context)
     {
         if (context == null) return;
 
-        foreach (var entry in context.ChangeTracker.Entries<BaseAuditableEntity>())
+        foreach (var entry in context.ChangeTracker.Entries<IDateAuditable>())
+        {
+            if (entry.State is EntityState.Added or EntityState.Modified || entry.HasChangedOwnedEntities())
+            {
+                var utcNow = _dateTime.GetUtcNow();
+                if (entry.State == EntityState.Added)
+                {
+                    entry.Entity.Created = utcNow;
+                }
+                entry.Entity.LastModified = utcNow;
+            }
+        }
+    }
+
+    public void UpdateUserAudit(DbContext? context)
+    {
+        if (context == null) return;
+
+        foreach (var entry in context.ChangeTracker.Entries<IUserAuditable>())
         {
             if (entry.State is EntityState.Added or EntityState.Modified || entry.HasChangedOwnedEntities())
             {
@@ -45,10 +65,8 @@ public class AuditableEntityInterceptor : SaveChangesInterceptor
                 if (entry.State == EntityState.Added)
                 {
                     entry.Entity.CreatedBy = _user.Id;
-                    entry.Entity.Created = utcNow;
-                } 
+                }
                 entry.Entity.LastModifiedBy = _user.Id;
-                entry.Entity.LastModified = utcNow;
             }
         }
     }
@@ -57,8 +75,8 @@ public class AuditableEntityInterceptor : SaveChangesInterceptor
 public static class Extensions
 {
     public static bool HasChangedOwnedEntities(this EntityEntry entry) =>
-        entry.References.Any(r => 
-            r.TargetEntry != null && 
-            r.TargetEntry.Metadata.IsOwned() && 
+        entry.References.Any(r =>
+            r.TargetEntry != null &&
+            r.TargetEntry.Metadata.IsOwned() &&
             (r.TargetEntry.State == EntityState.Added || r.TargetEntry.State == EntityState.Modified));
 }

--- a/src/Infrastructure/Data/Interceptors/DispatchDomainEventsInterceptor.cs
+++ b/src/Infrastructure/Data/Interceptors/DispatchDomainEventsInterceptor.cs
@@ -1,4 +1,4 @@
-﻿using CleanArchitecture.Domain.Common;
+﻿using CleanArchitecture.Domain.Interfaces;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -34,7 +34,7 @@ public class DispatchDomainEventsInterceptor : SaveChangesInterceptor
         if (context == null) return;
 
         var entities = context.ChangeTracker
-            .Entries<BaseEntity>()
+            .Entries<IHasDomainEvents>()
             .Where(e => e.Entity.DomainEvents.Any())
             .Select(e => e.Entity);
 

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -1,9 +1,9 @@
 ﻿using CleanArchitecture.Application.Common.Interfaces;
 using CleanArchitecture.Domain.Constants;
+using CleanArchitecture.Domain.Entities;
 using CleanArchitecture.Infrastructure.Data;
 using CleanArchitecture.Infrastructure.Data.Interceptors;
 using CleanArchitecture.Infrastructure.Identity;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
@@ -52,14 +52,14 @@ public static class DependencyInjection
         builder.Services.AddAuthorizationBuilder();
 
         builder.Services
-            .AddIdentityCore<ApplicationUser>()
-            .AddRoles<IdentityRole>()
+            .AddIdentityCore<User>()
+            .AddRoles<ApplicationRole>()
             .AddEntityFrameworkStores<ApplicationDbContext>()
             .AddApiEndpoints();
 #else
         builder.Services
-            .AddDefaultIdentity<ApplicationUser>()
-            .AddRoles<IdentityRole>()
+            .AddDefaultIdentity<User>()
+            .AddRoles<ApplicationRole>()
             .AddEntityFrameworkStores<ApplicationDbContext>();
 #endif
 

--- a/src/Infrastructure/Identity/ApplicationUser.cs
+++ b/src/Infrastructure/Identity/ApplicationUser.cs
@@ -1,7 +1,0 @@
-﻿using Microsoft.AspNetCore.Identity;
-
-namespace CleanArchitecture.Infrastructure.Identity;
-
-public class ApplicationUser : IdentityUser
-{
-}

--- a/src/Infrastructure/Identity/IdentityService.cs
+++ b/src/Infrastructure/Identity/IdentityService.cs
@@ -1,5 +1,6 @@
 using CleanArchitecture.Application.Common.Interfaces;
 using CleanArchitecture.Application.Common.Models;
+using CleanArchitecture.Domain.Entities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -8,13 +9,13 @@ namespace CleanArchitecture.Infrastructure.Identity;
 
 public class IdentityService : IIdentityService
 {
-    private readonly UserManager<ApplicationUser> _userManager;
-    private readonly IUserClaimsPrincipalFactory<ApplicationUser> _userClaimsPrincipalFactory;
+    private readonly UserManager<User> _userManager;
+    private readonly IUserClaimsPrincipalFactory<User> _userClaimsPrincipalFactory;
     private readonly IAuthorizationService _authorizationService;
 
     public IdentityService(
-        UserManager<ApplicationUser> userManager,
-        IUserClaimsPrincipalFactory<ApplicationUser> userClaimsPrincipalFactory,
+        UserManager<User> userManager,
+        IUserClaimsPrincipalFactory<User> userClaimsPrincipalFactory,
         IAuthorizationService authorizationService)
     {
         _userManager = userManager;
@@ -31,11 +32,7 @@ public class IdentityService : IIdentityService
 
     public async Task<(Result Result, string UserId)> CreateUserAsync(string userName, string password)
     {
-        var user = new ApplicationUser
-        {
-            UserName = userName,
-            Email = userName,
-        };
+        var user = new User(userName.Split('@')[0], userName);
 
         var result = await _userManager.CreateAsync(user, password);
 
@@ -72,10 +69,17 @@ public class IdentityService : IIdentityService
         return user != null ? await DeleteUserAsync(user) : Result.Success();
     }
 
-    public async Task<Result> DeleteUserAsync(ApplicationUser user)
+    public async Task<Result> DeleteUserAsync(User user)
     {
         var result = await _userManager.DeleteAsync(user);
 
         return result.ToApplicationResult();
     }
+
+    public async Task<User?> GetUserByIdAsync(string userId)
+        => await _userManager.Users
+             .Where(x => x.Id == userId)
+             .Include(x => x.UserRoles)
+             .ThenInclude(x => x.Role)
+             .FirstOrDefaultAsync();
 }

--- a/src/Web/Endpoints/Users.cs
+++ b/src/Web/Endpoints/Users.cs
@@ -1,5 +1,5 @@
 ﻿#if (UseApiOnly)
-using CleanArchitecture.Infrastructure.Identity;
+using CleanArchitecture.Domain.Entities;
 
 namespace CleanArchitecture.Web.Endpoints;
 
@@ -8,7 +8,7 @@ public class Users : EndpointGroupBase
     public override void Map(WebApplication app)
     {
         app.MapGroup(this)
-            .MapIdentityApi<ApplicationUser>();
+            .MapIdentityApi<User>();
     }
 }
 #endif

--- a/src/Web/Pages/Shared/_LoginPartial.cshtml
+++ b/src/Web/Pages/Shared/_LoginPartial.cshtml
@@ -1,7 +1,7 @@
-﻿@using CleanArchitecture.Infrastructure.Identity
+﻿@using CleanArchitecture.Domain.Entities
 @using Microsoft.AspNetCore.Identity
-@inject SignInManager<ApplicationUser> SignInManager
-@inject UserManager<ApplicationUser> UserManager
+@inject SignInManager<User> SignInManager
+@inject UserManager<User> UserManager
 
 @{
     string? returnUrl = null;

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -14,15 +14,9 @@ builder.AddWebServices();
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    await app.InitialiseDatabaseAsync();
-}
-else
-{
-    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-    app.UseHsts();
-}
+await app.InitialiseDatabaseAsync();
+// The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+app.UseHsts();
 
 #if (!UseAspire)
 app.UseHealthChecks("/health");

--- a/tests/Application.FunctionalTests/Testing.cs
+++ b/tests/Application.FunctionalTests/Testing.cs
@@ -1,4 +1,5 @@
 ﻿using CleanArchitecture.Domain.Constants;
+using CleanArchitecture.Domain.Entities;
 using CleanArchitecture.Infrastructure.Data;
 using CleanArchitecture.Infrastructure.Identity;
 using MediatR;
@@ -63,9 +64,9 @@ public partial class Testing
     {
         using var scope = _scopeFactory.CreateScope();
 
-        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
 
-        var user = new ApplicationUser { UserName = userName, Email = userName };
+        var user = new User { UserName = userName, Email = userName };
 
         var result = await userManager.CreateAsync(user, password);
 


### PR DESCRIPTION
- Moved `ApplicationUser` from Infrastructure to Domain and renamed it to `User`.
- Refactored `BaseAuditableEntity` by introducing `IDateAuditable` and `IUserAuditable` to separate concerns and support updates in `AuditableEntityInterceptor`.
- Added `ApplicationRole` and `UserRole` entities to enable proper mapping to `UserDto`.
- Refactored `ApplicationDbContextInitializer` and `Program.cs` for better Development environment configuration.
- Added `GetUserByIdAsync` method to `IdentityService`.
- Introduced `IHasDomainEvents` and implemented it in the `User` entity; also inherited it in `BaseEntity` to support domain event handling for aggregate roots.