### PR TITLE
Refactor Domain and Infrastrucuture

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.6.2" />

--- a/src/Application/Account/EventHandlers/LogUserCreatedEventHandler.cs
+++ b/src/Application/Account/EventHandlers/LogUserCreatedEventHandler.cs
@@ -1,0 +1,13 @@
+﻿using CleanArchitecture.Domain.Events;
+using Microsoft.Extensions.Logging;
+
+namespace CleanArchitecture.Application.Account.EventHandlers;
+
+internal sealed class LogUserCreatedEventHandler(ILogger<LogUserCreatedEventHandler> logger) : INotificationHandler<UserCreatedEvent>
+{
+    public Task Handle(UserCreatedEvent notification, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("{userName} is created", notification.DisplayName);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Application/Account/Queries/UserProfile/UserProfile.cs
+++ b/src/Application/Account/Queries/UserProfile/UserProfile.cs
@@ -1,0 +1,29 @@
+﻿using CleanArchitecture.Application.Common.Interfaces;
+using CleanArchitecture.Application.Common.Models;
+
+namespace CleanArchitecture.Application.Account.Queries.UserProfile;
+
+public record UserProfileQuery : IRequest<UserDto?>;
+
+public class UserProfileQueryValidator : AbstractValidator<UserProfileQuery>
+{
+    public UserProfileQueryValidator()
+    {
+    }
+}
+
+public class UserProfileQueryHandler(IIdentityService identityService, IUser user, IMapper mapper) : IRequestHandler<UserProfileQuery, UserDto?>
+{
+    private readonly IIdentityService _identityService = identityService;
+    private readonly IUser _currentUser = user;
+    private readonly IMapper _mapper = mapper;
+
+    public async Task<UserDto?> Handle(UserProfileQuery request, CancellationToken cancellationToken)
+    {
+        var user = string.IsNullOrEmpty(_currentUser.Id)
+            ? throw new UnauthorizedAccessException("User not logged in.")
+            : await _identityService.GetUserByIdAsync(_currentUser.Id);
+
+        return _mapper.Map<UserDto?>(user);
+    }
+}

--- a/src/Application/Common/Interfaces/IIdentityService.cs
+++ b/src/Application/Common/Interfaces/IIdentityService.cs
@@ -1,4 +1,5 @@
 ﻿using CleanArchitecture.Application.Common.Models;
+using CleanArchitecture.Domain.Entities;
 
 namespace CleanArchitecture.Application.Common.Interfaces;
 
@@ -13,4 +14,6 @@ public interface IIdentityService
     Task<(Result Result, string UserId)> CreateUserAsync(string userName, string password);
 
     Task<Result> DeleteUserAsync(string userId);
+
+    Task<User?> GetUserByIdAsync(string userId);
 }

--- a/src/Application/Common/Models/UserDto.cs
+++ b/src/Application/Common/Models/UserDto.cs
@@ -1,0 +1,22 @@
+﻿using CleanArchitecture.Domain.Entities;
+
+namespace CleanArchitecture.Application.Common.Models;
+
+public record UserDto
+{
+    public string? Id { get; init; }
+    public string? DisplayName { get; init; }
+    public string? Email { get; init; }
+    public string? PhoneNumber { get; init; }
+    public bool EmailConfirmed { get; init; }
+    public bool PhoneNumberConfirmed { get; init; }
+    public IReadOnlyCollection<string> Roles { get; init; } = [];
+    private class Mapping : Profile
+    {
+        public Mapping()
+        {
+            CreateMap<User, UserDto>()
+                .ForMember(dest => dest.Roles, o => o.MapFrom(src => src.UserRoles.Select(r => r.Role.Name).ToList()));
+        }
+    }
+}

--- a/src/Domain/Common/BaseAuditableEntity.cs
+++ b/src/Domain/Common/BaseAuditableEntity.cs
@@ -1,6 +1,6 @@
 ﻿namespace CleanArchitecture.Domain.Common;
 
-public abstract class BaseAuditableEntity : BaseEntity
+public abstract class BaseAuditableEntity : BaseEntity, IDatetimeAuditable, IUserAuditable
 {
     public DateTimeOffset Created { get; set; }
 

--- a/src/Domain/Common/BaseEntity.cs
+++ b/src/Domain/Common/BaseEntity.cs
@@ -8,23 +8,14 @@ public abstract class BaseEntity
     // Using non-generic integer types for simplicity
     public int Id { get; set; }
 
-    private readonly List<BaseEvent> _domainEvents = new();
+    private readonly List<BaseEvent> _domainEvents = [];
 
     [NotMapped]
     public IReadOnlyCollection<BaseEvent> DomainEvents => _domainEvents.AsReadOnly();
 
-    public void AddDomainEvent(BaseEvent domainEvent)
-    {
-        _domainEvents.Add(domainEvent);
-    }
+    public void AddDomainEvent(BaseEvent domainEvent) => _domainEvents.Add(domainEvent);
 
-    public void RemoveDomainEvent(BaseEvent domainEvent)
-    {
-        _domainEvents.Remove(domainEvent);
-    }
+    public void RemoveDomainEvent(BaseEvent domainEvent) => _domainEvents.Remove(domainEvent);
 
-    public void ClearDomainEvents()
-    {
-        _domainEvents.Clear();
-    }
+    public void ClearDomainEvents() => _domainEvents.Clear();
 }

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR.Contracts" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" />
   </ItemGroup>
 
 </Project>

--- a/src/Domain/Entities/ApplicationRole.cs
+++ b/src/Domain/Entities/ApplicationRole.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace CleanArchitecture.Domain.Entities;
+
+public class ApplicationRole : IdentityRole
+{
+    public virtual ICollection<UserRole> UserRoles { get; set; } = [];
+    public ApplicationRole() { }
+    public ApplicationRole(string roleName) : base(roleName) { }
+}

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -1,0 +1,32 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.AspNetCore.Identity;
+
+namespace CleanArchitecture.Domain.Entities;
+
+/// <summary>
+/// User identity entity, It has the <see cref="IHasDomainEvents"/> domain events for logs or other business logic to perform.
+/// </summary>
+public class User : IdentityUser, IHasDomainEvents
+{
+    public string DisplayName { get; private set; } = null!;
+
+    public virtual ICollection<UserRole> UserRoles { get; set; } = [];
+
+    private readonly List<BaseEvent> _domainEvents = [];
+    [NotMapped]
+    public IReadOnlyCollection<BaseEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    public User() { }
+    public User(string displayName, string userName)
+    {
+        DisplayName = displayName;
+        UserName = userName;
+        Email = userName;
+    }
+
+    public void AddDomainEvent(BaseEvent domainEvent) => _domainEvents.Add(domainEvent);
+
+    public void RemoveDomainEvent(BaseEvent domainEvent) => _domainEvents.Remove(domainEvent);
+
+    public void ClearDomainEvents() => _domainEvents.Clear();
+}

--- a/src/Domain/Entities/UserRole.cs
+++ b/src/Domain/Entities/UserRole.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace CleanArchitecture.Domain.Entities;
+
+public class UserRole : IdentityUserRole<string>
+{
+    public virtual User User { get; set; } = null!;
+    public virtual ApplicationRole Role { get; set; } = null!;
+}

--- a/src/Domain/Events/UserCreatedEvent.cs
+++ b/src/Domain/Events/UserCreatedEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace CleanArchitecture.Domain.Events;
+
+public class UserCreatedEvent(string displayName, string? email) : BaseEvent
+{
+    public string DisplayName => displayName;
+    public string? Email => email;
+}

--- a/src/Domain/GlobalUsings.cs
+++ b/src/Domain/GlobalUsings.cs
@@ -4,3 +4,4 @@ global using CleanArchitecture.Domain.Enums;
 global using CleanArchitecture.Domain.Events;
 global using CleanArchitecture.Domain.Exceptions;
 global using CleanArchitecture.Domain.ValueObjects;
+global using CleanArchitecture.Domain.Interfaces;

--- a/src/Domain/Interfaces/IDatetimeAuditable.cs
+++ b/src/Domain/Interfaces/IDatetimeAuditable.cs
@@ -1,0 +1,7 @@
+﻿namespace CleanArchitecture.Domain.Interfaces;
+
+public interface IDatetimeAuditable
+{
+    public DateTimeOffset Created { get; set; }
+    public DateTimeOffset LastModified { get; set; }
+}

--- a/src/Domain/Interfaces/IHasDomainEvents.cs
+++ b/src/Domain/Interfaces/IHasDomainEvents.cs
@@ -1,0 +1,9 @@
+﻿namespace CleanArchitecture.Domain.Interfaces;
+
+public interface IHasDomainEvents
+{
+    IReadOnlyCollection<BaseEvent> DomainEvents { get; }
+    void AddDomainEvent(BaseEvent domainEvent);
+    void RemoveDomainEvent(BaseEvent domainEvent);
+    void ClearDomainEvents();
+}

--- a/src/Domain/Interfaces/IUserAuditable.cs
+++ b/src/Domain/Interfaces/IUserAuditable.cs
@@ -1,0 +1,7 @@
+﻿namespace CleanArchitecture.Domain.Interfaces;
+
+public interface IUserAuditable
+{
+    public string? CreatedBy { get; set; }
+    public string? LastModifiedBy { get; set; }
+}

--- a/src/Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/Data/ApplicationDbContext.cs
@@ -1,13 +1,13 @@
 ﻿using System.Reflection;
 using CleanArchitecture.Application.Common.Interfaces;
 using CleanArchitecture.Domain.Entities;
-using CleanArchitecture.Infrastructure.Identity;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace CleanArchitecture.Infrastructure.Data;
 
-public class ApplicationDbContext : IdentityDbContext<ApplicationUser>, IApplicationDbContext
+public class ApplicationDbContext : IdentityDbContext<User, ApplicationRole, string, IdentityUserClaim<string>, UserRole, IdentityUserLogin<string>, IdentityRoleClaim<string>, IdentityUserToken<string>>, IApplicationDbContext
 {
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
 

--- a/src/Infrastructure/Data/ApplicationDbContextInitialiser.cs
+++ b/src/Infrastructure/Data/ApplicationDbContextInitialiser.cs
@@ -1,9 +1,10 @@
 ﻿using CleanArchitecture.Domain.Constants;
 using CleanArchitecture.Domain.Entities;
-using CleanArchitecture.Infrastructure.Identity;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace CleanArchitecture.Infrastructure.Data;
@@ -16,7 +17,7 @@ public static class InitialiserExtensions
 
         var initialiser = scope.ServiceProvider.GetRequiredService<ApplicationDbContextInitialiser>();
 
-        await initialiser.InitialiseAsync();
+        await initialiser.InitialiseAsync(app.Environment.IsDevelopment());
         await initialiser.SeedAsync();
     }
 }
@@ -25,10 +26,10 @@ public class ApplicationDbContextInitialiser
 {
     private readonly ILogger<ApplicationDbContextInitialiser> _logger;
     private readonly ApplicationDbContext _context;
-    private readonly UserManager<ApplicationUser> _userManager;
-    private readonly RoleManager<IdentityRole> _roleManager;
+    private readonly UserManager<User> _userManager;
+    private readonly RoleManager<ApplicationRole> _roleManager;
 
-    public ApplicationDbContextInitialiser(ILogger<ApplicationDbContextInitialiser> logger, ApplicationDbContext context, UserManager<ApplicationUser> userManager, RoleManager<IdentityRole> roleManager)
+    public ApplicationDbContextInitialiser(ILogger<ApplicationDbContextInitialiser> logger, ApplicationDbContext context, UserManager<User> userManager, RoleManager<ApplicationRole> roleManager)
     {
         _logger = logger;
         _context = context;
@@ -36,13 +37,21 @@ public class ApplicationDbContextInitialiser
         _roleManager = roleManager;
     }
 
-    public async Task InitialiseAsync()
+    public async Task InitialiseAsync(bool isDevelopment)
     {
         try
         {
-            // See https://jasontaylor.dev/ef-core-database-initialisation-strategies
-            await _context.Database.EnsureDeletedAsync();
-            await _context.Database.EnsureCreatedAsync();
+            // You can add .IsNpgsql or .IsSqlServer or .IsSqlite method with isDevelopment, ex :  if (isDevelopment && _context.Database.IsSqlServer())
+            if (isDevelopment)
+            {
+                // See https://jasontaylor.dev/ef-core-database-initialisation-strategies
+                await _context.Database.EnsureDeletedAsync();
+                await _context.Database.EnsureCreatedAsync();
+            }
+            else if (!isDevelopment)
+            {
+                await _context.Database.MigrateAsync();
+            }
         }
         catch (Exception ex)
         {
@@ -66,25 +75,8 @@ public class ApplicationDbContextInitialiser
 
     public async Task TrySeedAsync()
     {
-        // Default roles
-        var administratorRole = new IdentityRole(Roles.Administrator);
-
-        if (_roleManager.Roles.All(r => r.Name != administratorRole.Name))
-        {
-            await _roleManager.CreateAsync(administratorRole);
-        }
-
-        // Default users
-        var administrator = new ApplicationUser { UserName = "administrator@localhost", Email = "administrator@localhost" };
-
-        if (_userManager.Users.All(u => u.UserName != administrator.UserName))
-        {
-            await _userManager.CreateAsync(administrator, "Administrator1!");
-            if (!string.IsNullOrWhiteSpace(administratorRole.Name))
-            {
-                await _userManager.AddToRolesAsync(administrator, new [] { administratorRole.Name });
-            }
-        }
+        await SeedRolesAsync();
+        await SeedAdminUserAsync();
 
         // Default data
         // Seed, if necessary
@@ -103,6 +95,70 @@ public class ApplicationDbContextInitialiser
             });
 
             await _context.SaveChangesAsync();
+        }
+    }
+
+    //============== Helpers ==============
+    async Task SeedRolesAsync()
+    {
+        try
+        {
+            var roles = typeof(Roles)
+                .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.FlattenHierarchy | System.Reflection.BindingFlags.Static)
+                .Where(t => t.IsLiteral && !t.IsInitOnly)
+                .Select(st => st.GetRawConstantValue()?.ToString())
+                .Select(role => new ApplicationRole(role!))
+                .ToList();
+
+            var tasks = roles.Select(async role =>
+            {
+                try
+                {
+                    if (!await _roleManager.RoleExistsAsync(role.Name!))
+                    {
+                        await _roleManager.CreateAsync(role);
+                        _logger.LogInformation("{roleName} added", role.Name);
+                    }
+                    else
+                    {
+                        _logger.LogInformation("Skipping {roleName}, already exist.", role.Name ?? "<null>");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "An error occured while seeding {roleName}", role.Name);
+                    throw;
+                }
+            });
+
+            await Task.WhenAll(tasks);
+
+            _logger.LogInformation("Roles {roles} are added successfully.", string.Join(';', roles
+                .Select(r => r.Name)));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occured while seeding roles");
+            throw;
+        }
+    }
+
+    async Task SeedAdminUserAsync()
+    {
+        try
+        {
+            var user = new User("Admin user", "administrator@localhost");
+
+            if (_userManager.Users.All(x => x.UserName != user.UserName))
+            {
+                await _userManager.CreateAsync(user, "Administrator1!");
+                await _userManager.AddToRoleAsync(user, Roles.Administrator);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogInformation(ex, "An error occured while seeding admin user.");
+            throw;
         }
     }
 }

--- a/src/Infrastructure/Data/Configurations/UserRoleConfiguration.cs
+++ b/src/Infrastructure/Data/Configurations/UserRoleConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using CleanArchitecture.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CleanArchitecture.Infrastructure.Data.Configurations;
+
+internal sealed class UserRoleConfiguration : IEntityTypeConfiguration<UserRole>
+{
+    public void Configure(EntityTypeBuilder<UserRole> builder)
+    {
+        builder.HasOne(x => x.User)
+            .WithMany(x => x.UserRoles)
+            .HasForeignKey(x => x.UserId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Cascade); // You can change it as per requirement.
+
+        builder.HasOne(x => x.Role)
+            .WithMany(x => x.UserRoles)
+            .HasForeignKey(x => x.RoleId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.NoAction); // You can change it as per requirement.
+    }
+}

--- a/src/Infrastructure/Data/Interceptors/AuditableEntityInterceptor.cs
+++ b/src/Infrastructure/Data/Interceptors/AuditableEntityInterceptor.cs
@@ -1,5 +1,5 @@
 ﻿using CleanArchitecture.Application.Common.Interfaces;
-using CleanArchitecture.Domain.Common;
+using CleanArchitecture.Domain.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -21,23 +21,43 @@ public class AuditableEntityInterceptor : SaveChangesInterceptor
 
     public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
     {
-        UpdateEntities(eventData.Context);
+        UpdateDatetimeAudits(eventData.Context);
+        UpdateUserAudits(eventData.Context);
 
         return base.SavingChanges(eventData, result);
     }
 
     public override ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
     {
-        UpdateEntities(eventData.Context);
+        UpdateDatetimeAudits(eventData.Context);
+        UpdateUserAudits(eventData.Context);
 
         return base.SavingChangesAsync(eventData, result, cancellationToken);
     }
 
-    public void UpdateEntities(DbContext? context)
+    public void UpdateDatetimeAudits(DbContext? context)
     {
         if (context == null) return;
 
-        foreach (var entry in context.ChangeTracker.Entries<BaseAuditableEntity>())
+        foreach (var entry in context.ChangeTracker.Entries<IDatetimeAuditable>())
+        {
+            if (entry.State is EntityState.Added or EntityState.Modified || entry.HasChangedOwnedEntities())
+            {
+                var utcNow = _dateTime.GetUtcNow();
+                if (entry.State == EntityState.Added)
+                {
+                    entry.Entity.Created = utcNow;
+                }
+                entry.Entity.LastModified = utcNow;
+            }
+        }
+    }
+
+    public void UpdateUserAudits(DbContext? context)
+    {
+        if (context == null) return;
+
+        foreach (var entry in context.ChangeTracker.Entries<IUserAuditable>())
         {
             if (entry.State is EntityState.Added or EntityState.Modified || entry.HasChangedOwnedEntities())
             {
@@ -45,10 +65,8 @@ public class AuditableEntityInterceptor : SaveChangesInterceptor
                 if (entry.State == EntityState.Added)
                 {
                     entry.Entity.CreatedBy = _user.Id;
-                    entry.Entity.Created = utcNow;
-                } 
+                }
                 entry.Entity.LastModifiedBy = _user.Id;
-                entry.Entity.LastModified = utcNow;
             }
         }
     }
@@ -57,8 +75,8 @@ public class AuditableEntityInterceptor : SaveChangesInterceptor
 public static class Extensions
 {
     public static bool HasChangedOwnedEntities(this EntityEntry entry) =>
-        entry.References.Any(r => 
-            r.TargetEntry != null && 
-            r.TargetEntry.Metadata.IsOwned() && 
+        entry.References.Any(r =>
+            r.TargetEntry != null &&
+            r.TargetEntry.Metadata.IsOwned() &&
             (r.TargetEntry.State == EntityState.Added || r.TargetEntry.State == EntityState.Modified));
 }

--- a/src/Infrastructure/Data/Interceptors/DispatchDomainEventsInterceptor.cs
+++ b/src/Infrastructure/Data/Interceptors/DispatchDomainEventsInterceptor.cs
@@ -1,4 +1,4 @@
-﻿using CleanArchitecture.Domain.Common;
+﻿using CleanArchitecture.Domain.Interfaces;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -34,7 +34,7 @@ public class DispatchDomainEventsInterceptor : SaveChangesInterceptor
         if (context == null) return;
 
         var entities = context.ChangeTracker
-            .Entries<BaseEntity>()
+            .Entries<IHasDomainEvents>()
             .Where(e => e.Entity.DomainEvents.Any())
             .Select(e => e.Entity);
 

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -1,9 +1,9 @@
 ﻿using CleanArchitecture.Application.Common.Interfaces;
 using CleanArchitecture.Domain.Constants;
+using CleanArchitecture.Domain.Entities;
 using CleanArchitecture.Infrastructure.Data;
 using CleanArchitecture.Infrastructure.Data.Interceptors;
 using CleanArchitecture.Infrastructure.Identity;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
@@ -53,14 +53,14 @@ public static class DependencyInjection
         builder.Services.AddAuthorizationBuilder();
 
         builder.Services
-            .AddIdentityCore<ApplicationUser>()
-            .AddRoles<IdentityRole>()
+            .AddIdentityCore<User>()
+            .AddRoles<ApplicationRole>()
             .AddEntityFrameworkStores<ApplicationDbContext>()
             .AddApiEndpoints();
 #else
         builder.Services
-            .AddDefaultIdentity<ApplicationUser>()
-            .AddRoles<IdentityRole>()
+            .AddDefaultIdentity<User>()
+            .AddRoles<ApplicationRole>()
             .AddEntityFrameworkStores<ApplicationDbContext>();
 #endif
 

--- a/src/Infrastructure/Identity/ApplicationUser.cs
+++ b/src/Infrastructure/Identity/ApplicationUser.cs
@@ -1,7 +1,0 @@
-﻿using Microsoft.AspNetCore.Identity;
-
-namespace CleanArchitecture.Infrastructure.Identity;
-
-public class ApplicationUser : IdentityUser
-{
-}

--- a/src/Infrastructure/Identity/IdentityService.cs
+++ b/src/Infrastructure/Identity/IdentityService.cs
@@ -1,5 +1,7 @@
 using CleanArchitecture.Application.Common.Interfaces;
 using CleanArchitecture.Application.Common.Models;
+using CleanArchitecture.Domain.Entities;
+using CleanArchitecture.Domain.Events;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -8,13 +10,13 @@ namespace CleanArchitecture.Infrastructure.Identity;
 
 public class IdentityService : IIdentityService
 {
-    private readonly UserManager<ApplicationUser> _userManager;
-    private readonly IUserClaimsPrincipalFactory<ApplicationUser> _userClaimsPrincipalFactory;
+    private readonly UserManager<User> _userManager;
+    private readonly IUserClaimsPrincipalFactory<User> _userClaimsPrincipalFactory;
     private readonly IAuthorizationService _authorizationService;
 
     public IdentityService(
-        UserManager<ApplicationUser> userManager,
-        IUserClaimsPrincipalFactory<ApplicationUser> userClaimsPrincipalFactory,
+        UserManager<User> userManager,
+        IUserClaimsPrincipalFactory<User> userClaimsPrincipalFactory,
         IAuthorizationService authorizationService)
     {
         _userManager = userManager;
@@ -31,11 +33,9 @@ public class IdentityService : IIdentityService
 
     public async Task<(Result Result, string UserId)> CreateUserAsync(string userName, string password)
     {
-        var user = new ApplicationUser
-        {
-            UserName = userName,
-            Email = userName,
-        };
+        var user = new User(userName.Split('@')[0], userName);
+
+        user.AddDomainEvent(new UserCreatedEvent(user.DisplayName, user.Email));
 
         var result = await _userManager.CreateAsync(user, password);
 
@@ -72,10 +72,17 @@ public class IdentityService : IIdentityService
         return user != null ? await DeleteUserAsync(user) : Result.Success();
     }
 
-    public async Task<Result> DeleteUserAsync(ApplicationUser user)
+    public async Task<Result> DeleteUserAsync(User user)
     {
         var result = await _userManager.DeleteAsync(user);
 
         return result.ToApplicationResult();
     }
+
+    public async Task<User?> GetUserByIdAsync(string userId)
+        => await _userManager.Users
+        .Where(x => x.Id == userId)
+        .Include(x => x.UserRoles)
+        .ThenInclude(x => x.Role)
+        .FirstOrDefaultAsync();
 }

--- a/src/Web/ClientApp/src/app/web-api-client.ts
+++ b/src/Web/ClientApp/src/app/web-api-client.ts
@@ -87,6 +87,18 @@ export class TodoItemsClient implements ITodoItemsClient {
             result200 = PaginatedListOfTodoItemBriefDto.fromJS(resultData200);
             return _observableOf(result200);
             }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Bad Request", status, _responseText, _headers);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Unauthorized", status, _responseText, _headers);
+            }));
+        } else if (status === 403) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Forbidden", status, _responseText, _headers);
+            }));
         } else if (status !== 200 && status !== 204) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
@@ -139,6 +151,18 @@ export class TodoItemsClient implements ITodoItemsClient {
                 result201 = resultData201 !== undefined ? resultData201 : null as any;
     
             return _observableOf(result201);
+            }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Bad Request", status, _responseText, _headers);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Unauthorized", status, _responseText, _headers);
+            }));
+        } else if (status === 403) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Forbidden", status, _responseText, _headers);
             }));
         } else if (status !== 200 && status !== 204) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
@@ -195,6 +219,14 @@ export class TodoItemsClient implements ITodoItemsClient {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
             return throwException("A server side error occurred.", status, _responseText, _headers);
             }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Unauthorized", status, _responseText, _headers);
+            }));
+        } else if (status === 403) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Forbidden", status, _responseText, _headers);
+            }));
         } else if (status !== 200 && status !== 204) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
@@ -241,6 +273,18 @@ export class TodoItemsClient implements ITodoItemsClient {
         if (status === 204) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
             return _observableOf(null as any);
+            }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Bad Request", status, _responseText, _headers);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Unauthorized", status, _responseText, _headers);
+            }));
+        } else if (status === 403) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Forbidden", status, _responseText, _headers);
             }));
         } else if (status !== 200 && status !== 204) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
@@ -296,6 +340,14 @@ export class TodoItemsClient implements ITodoItemsClient {
         } else if (status === 400) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
             return throwException("A server side error occurred.", status, _responseText, _headers);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Unauthorized", status, _responseText, _headers);
+            }));
+        } else if (status === 403) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Forbidden", status, _responseText, _headers);
             }));
         } else if (status !== 200 && status !== 204) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
@@ -366,6 +418,18 @@ export class TodoListsClient implements ITodoListsClient {
             result200 = TodosVm.fromJS(resultData200);
             return _observableOf(result200);
             }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Bad Request", status, _responseText, _headers);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Unauthorized", status, _responseText, _headers);
+            }));
+        } else if (status === 403) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Forbidden", status, _responseText, _headers);
+            }));
         } else if (status !== 200 && status !== 204) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
@@ -418,6 +482,18 @@ export class TodoListsClient implements ITodoListsClient {
                 result201 = resultData201 !== undefined ? resultData201 : null as any;
     
             return _observableOf(result201);
+            }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Bad Request", status, _responseText, _headers);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Unauthorized", status, _responseText, _headers);
+            }));
+        } else if (status === 403) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Forbidden", status, _responseText, _headers);
             }));
         } else if (status !== 200 && status !== 204) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
@@ -474,6 +550,14 @@ export class TodoListsClient implements ITodoListsClient {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
             return throwException("A server side error occurred.", status, _responseText, _headers);
             }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Unauthorized", status, _responseText, _headers);
+            }));
+        } else if (status === 403) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Forbidden", status, _responseText, _headers);
+            }));
         } else if (status !== 200 && status !== 204) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
@@ -520,6 +604,18 @@ export class TodoListsClient implements ITodoListsClient {
         if (status === 204) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
             return _observableOf(null as any);
+            }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Bad Request", status, _responseText, _headers);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Unauthorized", status, _responseText, _headers);
+            }));
+        } else if (status === 403) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Forbidden", status, _responseText, _headers);
             }));
         } else if (status !== 200 && status !== 204) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
@@ -593,6 +689,18 @@ export class WeatherForecastsClient implements IWeatherForecastsClient {
                 result200 = null as any;
             }
             return _observableOf(result200);
+            }));
+        } else if (status === 400) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Bad Request", status, _responseText, _headers);
+            }));
+        } else if (status === 401) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Unauthorized", status, _responseText, _headers);
+            }));
+        } else if (status === 403) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("Forbidden", status, _responseText, _headers);
             }));
         } else if (status !== 200 && status !== 204) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {

--- a/src/Web/Endpoints/Users.cs
+++ b/src/Web/Endpoints/Users.cs
@@ -1,5 +1,5 @@
 ﻿#if (UseApiOnly)
-using CleanArchitecture.Infrastructure.Identity;
+using CleanArchitecture.Domain.Entities;
 
 namespace CleanArchitecture.Web.Endpoints;
 
@@ -7,7 +7,7 @@ public class Users : EndpointGroupBase
 {
     public override void Map(RouteGroupBuilder groupBuilder)
     {
-        groupBuilder.MapIdentityApi<ApplicationUser>();
+        groupBuilder.MapIdentityApi<User>();
     }
 }
 #endif

--- a/src/Web/Pages/Shared/_LoginPartial.cshtml
+++ b/src/Web/Pages/Shared/_LoginPartial.cshtml
@@ -1,7 +1,7 @@
-﻿@using CleanArchitecture.Infrastructure.Identity
+﻿@using CleanArchitecture.Domain.Entities
 @using Microsoft.AspNetCore.Identity
-@inject SignInManager<ApplicationUser> SignInManager
-@inject UserManager<ApplicationUser> UserManager
+@inject SignInManager<User> SignInManager
+@inject UserManager<User> UserManager
 
 @{
     string? returnUrl = null;

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -14,15 +14,10 @@ builder.AddWebServices();
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    await app.InitialiseDatabaseAsync();
-}
-else
-{
-    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-    app.UseHsts();
-}
+await app.InitialiseDatabaseAsync();
+
+// The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+app.UseHsts();
 
 #if (!UseAspire)
 app.UseHealthChecks("/health");

--- a/src/Web/wwwroot/api/specification.json
+++ b/src/Web/wwwroot/api/specification.json
@@ -54,6 +54,15 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
           }
         }
       },
@@ -85,6 +94,15 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
           }
         }
       }
@@ -125,6 +143,12 @@
           },
           "400": {
             "description": ""
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
           }
         }
       },
@@ -148,6 +172,15 @@
         "responses": {
           "204": {
             "description": ""
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
           }
         }
       }
@@ -188,6 +221,12 @@
           },
           "400": {
             "description": ""
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
           }
         }
       }
@@ -208,6 +247,15 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
           }
         }
       },
@@ -239,6 +287,15 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
           }
         }
       }
@@ -279,6 +336,12 @@
           },
           "400": {
             "description": ""
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
           }
         }
       },
@@ -302,6 +365,15 @@
         "responses": {
           "204": {
             "description": ""
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
           }
         }
       }
@@ -325,6 +397,15 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
           }
         }
       }

--- a/tests/Application.FunctionalTests/Testing.cs
+++ b/tests/Application.FunctionalTests/Testing.cs
@@ -1,4 +1,5 @@
 ﻿using CleanArchitecture.Domain.Constants;
+using CleanArchitecture.Domain.Entities;
 using CleanArchitecture.Infrastructure.Data;
 using CleanArchitecture.Infrastructure.Identity;
 using MediatR;
@@ -48,7 +49,7 @@ public partial class Testing
     {
         return _userId;
     }
-    
+
     public static List<string>? GetRoles()
     {
         return _roles;
@@ -68,9 +69,9 @@ public partial class Testing
     {
         using var scope = _scopeFactory.CreateScope();
 
-        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
 
-        var user = new ApplicationUser { UserName = userName, Email = userName };
+        var user = new User { UserName = userName, Email = userName };
 
         var result = await userManager.CreateAsync(user, password);
 
@@ -104,7 +105,7 @@ public partial class Testing
         {
             await _database.ResetAsync();
         }
-        catch (Exception) 
+        catch (Exception)
         {
         }
 


### PR DESCRIPTION
- Moved `ApplicationUser` from Infrastructure to Domain and renamed it to `User`.
- Refactored `BaseAuditableEntity` by introducing `IDateAuditable` and `IUserAuditable` to separate concerns and support updates in `AuditableEntityInterceptor`.
- Added `ApplicationRole` and `UserRole` entities to enable proper mapping to `UserDto`.
- Refactored `ApplicationDbContextInitializer` and `Program.cs` for better Development environment configuration.
- Added `GetUserByIdAsync` method to `IdentityService`.
- Introduced `IHasDomainEvents` and implemented it in the `User` entity; also inherited it in `BaseEntity` to support domain event handling for aggregate roots.