### PR TITLE
chore: update package workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: Checkout code
 
       - uses: nuget/setup-nuget@v2


### PR DESCRIPTION
## Changes

- Upgrade actions/checkout v4 to v6

## Notes

Keeping GitHub Actions up to date with the latest versions for security and features.