### PR TITLE
chore: add Renovate for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":separateMajorReleases",
+    "group:allNonMajor"
+  ],
+  "labels": ["dependencies"],
+  "schedule": ["before 9am on monday"],
+  "timezone": "Australia/Brisbane",
+  "packageRules": [
+    {
+      "description": "Automerge non-major updates",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "automerge": true
+    },
+    {
+      "description": "Group .NET updates",
+      "matchManagers": ["nuget"],
+      "groupName": ".NET dependencies"
+    },
+    {
+      "description": "Group Angular updates",
+      "matchPackagePatterns": ["^@angular"],
+      "groupName": "Angular"
+    },
+    {
+      "description": "Group React updates",
+      "matchPackagePatterns": ["^react", "^@types/react"],
+      "groupName": "React"
+    },
+    {
+      "description": "Group testing packages",
+      "matchPackagePatterns": ["jest", "karma", "jasmine", "playwright", "nunit", "moq", "shouldly"],
+      "groupName": "Testing"
+    }
+  ]
+}


### PR DESCRIPTION
## Changes

Adds Renovate configuration to automate dependency updates.

### Configuration:
- **Schedule:** Monday mornings (Brisbane time)
- **Grouping:** Non-major updates grouped together, plus ecosystem-specific groups (Angular, React, .NET, GitHub Actions, Testing)
- **Automerge:** Minor and patch updates auto-merge when CI passes
- **Major versions:** Separate PRs for review

## After merging

1. Install the Renovate GitHub App: https://github.com/apps/renovate
2. Grant access to this repository
3. Renovate will create a 'Dependency Dashboard' issue and start raising PRs

## Why Renovate over Dependabot?

- Better grouping reduces PR noise
- Built-in automerge (no separate workflow needed)
- Better npm peer dependency handling
- Dashboard issue for visibility