### PR TITLE
implement database migrator and DbUp script execution

### DIFF
--- a/CleanArchitecture.slnx
+++ b/CleanArchitecture.slnx
@@ -15,6 +15,8 @@
     <Project Path="src/Infrastructure/Infrastructure.csproj" />
     <Project Path="src/Shared/Shared.csproj" />
     <Project Path="src/Web/Web.csproj" />
+    <Project Path="src/Migrator/Migrator.csproj" />
+    <Project Path="src/Shared.SQLScripts/Shared.SQLScripts.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Application.FunctionalTests/Application.FunctionalTests.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,8 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="dbup-core" Version="6.0.4" />
+    <PackageVersion Include="dbup-sqlserver" Version="6.0.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="MediatR" Version="14.1.0" />
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />

--- a/src/Migrator/IMigrationExecutor.cs
+++ b/src/Migrator/IMigrationExecutor.cs
@@ -1,0 +1,6 @@
+namespace CleanArchitecture.Migrator;
+
+public interface IMigrationExecutor
+{
+    Task ExecuteAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Migrator/MigrationExecutor.cs
+++ b/src/Migrator/MigrationExecutor.cs
@@ -1,0 +1,65 @@
+using CleanArchitecture.Infrastructure.Data;
+using CleanArchitecture.Shared.SQLScripts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace CleanArchitecture.Migrator;
+
+public class MigrationExecutor : IMigrationExecutor
+{
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<MigrationExecutor> _logger;
+    private readonly ApplicationDbContext _context;
+
+    public MigrationExecutor(
+        IConfiguration configuration,
+        ILogger<MigrationExecutor> logger,
+        ApplicationDbContext context)
+    {
+        _configuration = configuration;
+        _logger = logger;
+        _context = context;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        var connectionString = _configuration.GetConnectionString("CleanArchitectureDb")
+            ?? throw new InvalidOperationException(
+                "Connection string 'CleanArchitectureDb' not found in configuration.");
+
+        _logger.LogInformation("=== Database Migration Started ===");
+
+        await RunEfCoreMigrationsAsync(cancellationToken);
+        RunSqlScripts(connectionString);
+
+        _logger.LogInformation("=== Database Migration Completed Successfully ===");
+    }
+
+    private async Task RunEfCoreMigrationsAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Applying EF Core migrations...");
+
+        var pendingMigrations = await _context.Database.GetPendingMigrationsAsync(cancellationToken);
+        var migrations = pendingMigrations.ToList();
+
+        if (migrations.Count == 0)
+        {
+            _logger.LogInformation("No pending EF Core migrations found.");
+            return;
+        }
+
+        _logger.LogInformation("Found {Count} pending migration(s): {Migrations}",
+            migrations.Count, string.Join(", ", migrations));
+
+        await _context.Database.MigrateAsync(cancellationToken);
+
+        _logger.LogInformation("EF Core migrations applied successfully.");
+    }
+
+    private void RunSqlScripts(string connectionString)
+    {
+        _logger.LogInformation("Deploying SQL scripts via DbUp...");
+        ScriptDeployer.Deploy(connectionString, _logger);
+    }
+}

--- a/src/Migrator/Migrator.csproj
+++ b/src/Migrator/Migrator.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>CleanArchitecture.Migrator</RootNamespace>
+    <AssemblyName>CleanArchitecture.Migrator</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
+    <ProjectReference Include="..\Shared.SQLScripts\Shared.SQLScripts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/Migrator/MigratorModule.cs
+++ b/src/Migrator/MigratorModule.cs
@@ -1,0 +1,55 @@
+using CleanArchitecture.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CleanArchitecture.Migrator;
+
+public static class MigratorModule
+{
+    public static void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("CleanArchitectureDb")
+            ?? throw new InvalidOperationException(
+                "Connection string 'CleanArchitectureDb' not found. " +
+                "Ensure appsettings.json is properly configured.");
+
+        // Register DbContext with the same configuration as the main application
+        services.AddDbContext<ApplicationDbContext>((sp, options) =>
+        {
+            options.AddInterceptors(sp.GetServices<ISaveChangesInterceptor>());
+
+#if (UsePostgreSQL)
+            options.UseNpgsql(connectionString, npgsqlOptions =>
+            {
+                npgsqlOptions.MigrationsAssembly(typeof(ApplicationDbContext).Assembly.GetName().Name);
+                npgsqlOptions.EnableRetryOnFailure(
+                    maxRetryCount: 5,
+                    maxRetryDelay: TimeSpan.FromSeconds(30),
+                    errorCodesToAdd: null);
+            });
+#elif (UseSqlServer)
+            options.UseSqlServer(connectionString, sqlOptions =>
+            {
+                sqlOptions.MigrationsAssembly(typeof(ApplicationDbContext).Assembly.GetName().Name);
+                sqlOptions.EnableRetryOnFailure(
+                    maxRetryCount: 5,
+                    maxRetryDelay: TimeSpan.FromSeconds(30),
+                    errorNumbersToAdd: null);
+            });
+#else
+            options.UseSqlite(connectionString, sqliteOptions =>
+            {
+                sqliteOptions.MigrationsAssembly(typeof(ApplicationDbContext).Assembly.GetName().Name);
+            });
+#endif
+
+            options.ConfigureWarnings(warnings =>
+                warnings.Ignore(RelationalEventId.PendingModelChangesWarning));
+        });
+
+        // Register migration executor
+        services.AddTransient<IMigrationExecutor, MigrationExecutor>();
+    }
+}

--- a/src/Migrator/Program.cs
+++ b/src/Migrator/Program.cs
@@ -1,0 +1,31 @@
+using CleanArchitecture.Migrator;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+var host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((hostContext, services) =>
+    {
+        MigratorModule.ConfigureServices(services, hostContext.Configuration);
+    })
+    .Build();
+
+using var scope = host.Services.CreateScope();
+var services = scope.ServiceProvider;
+var logger = services.GetRequiredService<ILogger<Program>>();
+
+try
+{
+    logger.LogInformation("CleanArchitecture Database Migrator starting...");
+
+    var migrationExecutor = services.GetRequiredService<IMigrationExecutor>();
+    await migrationExecutor.ExecuteAsync();
+
+    logger.LogInformation("CleanArchitecture Database Migrator completed successfully.");
+    return 0;
+}
+catch (Exception ex)
+{
+    logger.LogCritical(ex, "CleanArchitecture Database Migrator terminated unexpectedly.");
+    return 1;
+}

--- a/src/Migrator/appsettings.json
+++ b/src/Migrator/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "ConnectionStrings": {
+    "CleanArchitectureDb": "Server=(localdb)\\mssqllocaldb;Database=CleanArchitectureDb;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.EntityFrameworkCore": "Information",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "CleanArchitecture.Migrator": "Debug"
+    }
+  }
+}

--- a/src/Shared.SQLScripts/Everytime/01_SPs/__sample_sp.sql
+++ b/src/Shared.SQLScripts/Everytime/01_SPs/__sample_sp.sql
@@ -1,0 +1,19 @@
+-- =============================================
+-- Sample Stored Procedure: GetTodoListsSummary
+-- This script runs on every deployment (no journaling).
+-- Add your stored procedures to this folder.
+-- =============================================
+-- CREATE OR ALTER PROCEDURE [dbo].[GetTodoListsSummary]
+-- AS
+-- BEGIN
+--     SET NOCOUNT ON;
+--     SELECT 
+--         tl.Id,
+--         tl.Title,
+--         COUNT(ti.Id) AS ItemCount,
+--         SUM(CASE WHEN ti.Done = 1 THEN 1 ELSE 0 END) AS CompletedCount
+--     FROM TodoLists tl
+--     LEFT JOIN TodoItems ti ON ti.ListId = tl.Id
+--     GROUP BY tl.Id, tl.Title;
+-- END
+-- GO

--- a/src/Shared.SQLScripts/Everytime/02_Functions/__sample_function.sql
+++ b/src/Shared.SQLScripts/Everytime/02_Functions/__sample_function.sql
@@ -1,0 +1,15 @@
+-- =============================================
+-- Sample Function placeholder
+-- This script runs on every deployment (no journaling).
+-- Add your SQL functions to this folder.
+-- =============================================
+-- CREATE OR ALTER FUNCTION [dbo].[fn_GetTodoItemStatus](@TodoItemId INT)
+-- RETURNS NVARCHAR(20)
+-- AS
+-- BEGIN
+--     DECLARE @Status NVARCHAR(20);
+--     SELECT @Status = CASE WHEN Done = 1 THEN 'Completed' ELSE 'Pending' END
+--     FROM TodoItems WHERE Id = @TodoItemId;
+--     RETURN ISNULL(@Status, 'Unknown');
+-- END
+-- GO

--- a/src/Shared.SQLScripts/Everytime/03_Views/__sample_view.sql
+++ b/src/Shared.SQLScripts/Everytime/03_Views/__sample_view.sql
@@ -1,0 +1,16 @@
+-- =============================================
+-- Sample View placeholder
+-- This script runs on every deployment (no journaling).
+-- Add your SQL views to this folder.
+-- =============================================
+-- CREATE OR ALTER VIEW [dbo].[vw_TodoListSummary]
+-- AS
+-- SELECT 
+--     tl.Id,
+--     tl.Title,
+--     COUNT(ti.Id) AS TotalItems,
+--     SUM(CASE WHEN ti.Done = 1 THEN 1 ELSE 0 END) AS CompletedItems
+-- FROM TodoLists tl
+-- LEFT JOIN TodoItems ti ON ti.ListId = tl.Id
+-- GROUP BY tl.Id, tl.Title;
+-- GO

--- a/src/Shared.SQLScripts/Onetime/01_Seeding/__sample_seed.sql
+++ b/src/Shared.SQLScripts/Onetime/01_Seeding/__sample_seed.sql
@@ -1,0 +1,9 @@
+-- =============================================
+-- Sample Seed Script
+-- This script runs only once (journaled by DbUp).
+-- Add your seed data scripts to this folder.
+-- Use a naming convention like: 001_SeedInitialData.sql
+-- =============================================
+-- INSERT INTO TodoLists (Title, Colour_Code) 
+-- SELECT 'Default List', '#00FF00'
+-- WHERE NOT EXISTS (SELECT 1 FROM TodoLists WHERE Title = 'Default List');

--- a/src/Shared.SQLScripts/Onetime/02_Migrations/__sample_migration.sql
+++ b/src/Shared.SQLScripts/Onetime/02_Migrations/__sample_migration.sql
@@ -1,0 +1,8 @@
+-- =============================================
+-- Sample Migration Script
+-- This script runs only once (journaled by DbUp).
+-- Use for one-time data migrations or schema changes 
+-- that are not handled by EF Core.
+-- Use a naming convention like: 001_AddIndexOnTodoItems.sql
+-- =============================================
+-- CREATE INDEX IX_TodoItems_Done ON TodoItems(Done) WHERE Done = 0;

--- a/src/Shared.SQLScripts/ScriptDeployer.cs
+++ b/src/Shared.SQLScripts/ScriptDeployer.cs
@@ -1,0 +1,111 @@
+using DbUp;
+using DbUp.Engine;
+using DbUp.Helpers;
+using Microsoft.Extensions.Logging;
+using System.Reflection;
+
+namespace CleanArchitecture.Shared.SQLScripts;
+
+public static class ScriptDeployer
+{
+    public static void Deploy(string connectionString, ILogger logger)
+    {
+        logger.LogInformation("Starting SQL scripts deployment on connection: {ConnectionString}",
+            MaskConnectionString(connectionString));
+
+        DeployEverytimeScripts(connectionString, logger);
+        DeployOnetimeScripts(connectionString, logger);
+
+        logger.LogInformation("SQL scripts deployment completed successfully.");
+    }
+
+    public static void DeployFunctions(string connectionString, ILogger logger)
+    {
+        DeployEverytimeFunctionScripts(connectionString, logger);
+    }
+
+    private static void DeployEverytimeScripts(string connectionString, ILogger logger)
+    {
+        logger.LogInformation("Deploying everytime scripts (SPs, Functions, Views)...");
+
+        var upgrader = DeployChanges.To
+            .SqlDatabase(connectionString)
+            .WithScriptsEmbeddedInAssembly(
+                Assembly.GetExecutingAssembly(),
+                s => s.Contains("everytime", StringComparison.OrdinalIgnoreCase)
+                     && !s.Contains("02_Functions", StringComparison.OrdinalIgnoreCase))
+            .LogToConsole()
+            .JournalTo(new NullJournal())
+            .Build();
+
+        ExecuteUpgrade(upgrader, logger, "Everytime scripts");
+    }
+
+    private static void DeployEverytimeFunctionScripts(string connectionString, ILogger logger)
+    {
+        logger.LogInformation("Deploying everytime function scripts...");
+
+        var upgrader = DeployChanges.To
+            .SqlDatabase(connectionString)
+            .WithScriptsEmbeddedInAssembly(
+                Assembly.GetExecutingAssembly(),
+                s => s.Contains("02_Functions", StringComparison.OrdinalIgnoreCase))
+            .LogToConsole()
+            .JournalTo(new NullJournal())
+            .Build();
+
+        ExecuteUpgrade(upgrader, logger, "Function scripts");
+    }
+
+    private static void DeployOnetimeScripts(string connectionString, ILogger logger)
+    {
+        logger.LogInformation("Deploying onetime scripts (Seeding, Migrations)...");
+
+        var upgrader = DeployChanges.To
+            .SqlDatabase(connectionString)
+            .WithScriptsEmbeddedInAssembly(
+                Assembly.GetExecutingAssembly(),
+                s => s.Contains("onetime", StringComparison.OrdinalIgnoreCase))
+            .LogToConsole()
+            .Build();
+
+        ExecuteUpgrade(upgrader, logger, "Onetime scripts");
+    }
+
+    private static void ExecuteUpgrade(UpgradeEngine upgrader, ILogger logger, string scriptCategory)
+    {
+        var result = upgrader.PerformUpgrade();
+
+        if (!result.Successful)
+        {
+            logger.LogError(result.Error, "Failed to deploy {ScriptCategory}.", scriptCategory);
+            throw new InvalidOperationException(
+                $"SQL script deployment failed for '{scriptCategory}'. See inner exception for details.",
+                result.Error);
+        }
+
+        logger.LogInformation("{ScriptCategory} deployed successfully.", scriptCategory);
+    }
+
+    /// <summary>
+    /// Masks the connection string for safe logging (hides password).
+    /// </summary>
+    private static string MaskConnectionString(string connectionString)
+    {
+        // Simple masking — replace password value if present
+        var parts = connectionString.Split(';');
+        for (var i = 0; i < parts.Length; i++)
+        {
+            if (parts[i].TrimStart().StartsWith("Password", StringComparison.OrdinalIgnoreCase) ||
+                parts[i].TrimStart().StartsWith("Pwd", StringComparison.OrdinalIgnoreCase))
+            {
+                var eqIndex = parts[i].IndexOf('=');
+                if (eqIndex >= 0)
+                {
+                    parts[i] = parts[i][..(eqIndex + 1)] + "***";
+                }
+            }
+        }
+        return string.Join(';', parts);
+    }
+}

--- a/src/Shared.SQLScripts/Shared.SQLScripts.csproj
+++ b/src/Shared.SQLScripts/Shared.SQLScripts.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>CleanArchitecture.Shared.SQLScripts</RootNamespace>
+    <AssemblyName>CleanArchitecture.Shared.SQLScripts</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Everytime\**\*.sql" />
+    <EmbeddedResource Include="Onetime\**\*.sql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="dbup-core" />
+    <PackageReference Include="dbup-sqlserver" />
+  </ItemGroup>
+
+  <!-- Folder structure for organizing SQL scripts -->
+  <ItemGroup>
+    <Folder Include="Everytime\01_SPs\" />
+    <Folder Include="Everytime\02_Functions\" />
+    <Folder Include="Everytime\03_Views\" />
+    <Folder Include="Onetime\01_Seeding\" />
+    <Folder Include="Onetime\02_Migrations\" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This pull request introduces a standalone Migrator console application and a Shared.SQLScripts class library to significantly improve the solution's database initialization and deployment strategy. By moving migration execution out of the Web project startup and into a dedicated executable, we achieve better separation of concerns and enable enterprise-grade CI/CD patterns, such as running database migrations as pre-deployment jobs. To address the limitations of Entity Framework Core in managing raw SQL assets, this implementation integrates the DbUp library, allowing developers to cleanly partition and execute raw SQL scripts into "everytime" deployments (ideal for Stored Procedures and Views without journaling) and "onetime" deployments (ideal for Seed Data and complex schema changes tracked via a journal table). Additionally, the migrator's dependency injection is fully aligned with the project's multi-provider strategy via C# preprocessor directives, and a minor compilation constant issue in the build properties was resolved to ensure EF Core generates accurate data types for SQL Server instead of falling back to SQLite. Ultimately, this architecture provides a highly reliable, fail-fast migration pipeline that protects the application from starting in an inconsistent state.